### PR TITLE
Add typed expression builder for feature query filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ This library provides a complete set of TypeScript interfaces, classes, and util
 import {
   AudiomEmbedConfig,
   AudiomSource,
+  Coordinates,
   StepSize,
   MapType,
   AudiomMessageHandler
-} from './audiom-client';
+} from 'audiom-embedder';
 ```
 
 ## Quick Start
@@ -36,12 +37,12 @@ import {
 const config = AudiomEmbedConfig.dynamic({
   apiKey: 'your-api-key-here',
   sources: ['osm'],
-  center: [-122.1431, 47.6495],
+  center: Coordinates.create(-122.1431, 47.6495),
   zoom: 15
 });
 
 const url = config.toUrl();
-// https://audiom-staging.herokuapp.com/embed/dynamic?apiKey=...&source=osm&center=-122.1431,47.6495&zoom=15
+// https://audiom-staging.herokuapp.com/embed/dynamic?apiKey=...&sources=osm&center=-122.1431,47.6495&zoom=15
 ```
 
 ### Static Map with Numeric ID
@@ -61,14 +62,14 @@ const url = config.toUrl();
 const config = AudiomEmbedConfig.dynamic({
   apiKey: 'your-api-key-here',
   sources: ['osm'],
-  center: [-122.1431, 47.6495],
-  stepsize: StepSize.Meters(10) // Type-safe step size
+  center: Coordinates.create(-122.1431, 47.6495),
+  stepSize: StepSize.meters(10) // Type-safe step size
 });
 
 // Alternative units:
-StepSize.Kilometers(5);
-StepSize.Miles(2);
-StepSize.Feet(100);
+StepSize.kilometers(5);
+StepSize.miles(2);
+StepSize.feet(100);
 StepSize.parse('50m'); // Parse from string
 ```
 
@@ -156,7 +157,7 @@ const config = AudiomEmbedConfig.dynamic({
       rules: '/rules/esri-indoor.json'
     })
   ],
-  center: [-117.1945001420124, 34.05679755835778]
+  center: Coordinates.create(-117.1945001420124, 34.05679755835778)
 });
 
 const url = config.toUrl();
@@ -165,21 +166,26 @@ const url = config.toUrl();
 ## Listening to User Position Updates
 
 ```typescript
+import {
+  AudiomMessageHandler,
+  AudiomOutboundEventType
+} from 'audiom-embedder';
+
 // Create message handler
-const messageHandler = new AudiomMessageHandler(
+const handler = new AudiomMessageHandler(
   'https://audiom-staging.herokuapp.com' // Optional: restrict to origin
 );
 
 // Add listener
-messageHandler.addUserPositionListener((position) => {
-  const [longitude, latitude] = position;
+handler.on(AudiomOutboundEventType.PositionChanged, (payload) => {
+  const [longitude, latitude] = payload.position;
   console.log('User moved to:', longitude, latitude);
   // Update your UI, sync with other maps, etc.
 });
 
 // Clean up when done
-messageHandler.removeAllListeners();
-messageHandler.dispose();
+handler.removeAllListeners();
+handler.dispose();
 ```
 
 ## Full Configuration Example
@@ -195,7 +201,7 @@ const config = AudiomEmbedConfig.dynamic({
       mapType: MapType.Indoor
     })
   ],
-  center: [-117.19, 34.06],
+  center: Coordinates.create(-117.19, 34.06),
   zoom: 18,
   title: 'Campus Indoor Navigation',
   soundpack: '/audio/campus',
@@ -203,7 +209,7 @@ const config = AudiomEmbedConfig.dynamic({
   showVisualMap: true,
   heading: 1,
   showHeading: true,
-  stepsize: StepSize.Meters(5),
+  stepSize: StepSize.meters(5),
   additionalParams: {
     organizationId: '12345',
     customFlag: true
@@ -230,20 +236,24 @@ const prodUrl = config.toUrlWithBase('https://audiom.example.com');
 - **`AudiomEmbedConfig`** - Main configuration class for embed maps
 - **`AudiomSource`** - Data source configuration
 - **`StepSize`** - Step size with unit support
-- **`AudiomMessageHandler`** - PostMessage communication handler
+- **`Coordinates`** - Geographic coordinate (longitude, latitude)
+- **`GeoQuad`** - Geographic quadrilateral (4 corners)
+- **`AudiomMessageHandler`** - Bidirectional PostMessage communication handler
 
 ### Enums
 
 - **`MapType`** - `Travel`, `Heatmap`, `Indoor`
 - **`SourceType`** - `OSM`, `TDEI`, `ESRI`, `GeoJSON`
 - **`StepSizeUnit`** - `Kilometers`, `Meters`, `Miles`, `Feet`
+- **`VisualStyle`** - `Geology`, `Indoor`, `Outdoor`, `Travel`
+- **`FilterMode`** - `Global`, `Scan`
 
 ### Types
 
-- **`Coordinates`** - `[longitude, latitude]` tuple
 - **`IAudiomEmbedConfig`** - Configuration interface
 - **`IAudiomSource`** - Source interface
-- **`AudiomUserPositionListener`** - Position update callback
+- **`AudiomOutboundMessage`** - Discriminated union of all outbound event messages
+- **`AudiomInboundCommand`** - Discriminated union of all inbound command messages
 
 ## Type Safety
 
@@ -255,11 +265,10 @@ const config: AudiomEmbedConfig = AudiomEmbedConfig.dynamic({
   heading: 1, // ✅ Valid (1-6)
   // heading: 7, // ❌ TypeScript error
   
-  center: [-122.14, 47.65], // ✅ [longitude, latitude]
-  // center: [47.65, -122.14], // ⚠️ No compile error, but logically incorrect
+  center: Coordinates.create(-122.14, 47.65), // ✅ Coordinates object
   
-  mapType: MapType.Indoor, // ✅ Type-safe enum
-  // mapType: 'invalid', // ❌ TypeScript error
+  visualStyle: VisualStyle.Indoor, // ✅ Type-safe enum
+  // visualStyle: 'invalid', // ❌ TypeScript error
 });
 ```
 
@@ -275,7 +284,7 @@ try {
 
 try {
   // Negative step size
-  const stepSize = StepSize.Meters(-5);
+  const stepSize = StepSize.meters(-5);
 } catch (error) {
   console.error('Step size must be positive:', error.message);
 }

--- a/src/AudiomEmbedConfig.params.test.ts
+++ b/src/AudiomEmbedConfig.params.test.ts
@@ -3,6 +3,7 @@ import { AudiomEmbedConfig, FilterMode, VisualStyle } from './AudiomEmbedConfig'
 import { StepSize } from './StepSize';
 import { SourceType, MapType } from './AudiomSource';
 import { Coordinates } from './Coordinates';
+import { field } from './expressions/AttributeFilter';
 
 describe('AudiomEmbedConfig query parameters', () => {
   describe('toQueryParams', () => {
@@ -278,7 +279,7 @@ describe('AudiomEmbedConfig query parameters', () => {
           type: SourceType.ESRI,
           url: 'https://example.com/arcgis/layer',
           mapType: MapType.Travel,
-          where: "type='building'"
+          where: field('type').eq('building')
         }]
       });
 
@@ -287,7 +288,7 @@ describe('AudiomEmbedConfig query parameters', () => {
       expect(params['myEsri.type']).toBe(SourceType.ESRI);
       expect(params['myEsri.url']).toBe('https://example.com/arcgis/layer');
       expect(params['myEsri.mapType']).toBe(MapType.Travel);
-      expect(params['myEsri.where']).toBe("type='building'");
+      expect(params['myEsri.where']).toBe("type = 'building'");
     });
   });
 });

--- a/src/AudiomSource.test.ts
+++ b/src/AudiomSource.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { AudiomSource, SourceType, MapType } from './AudiomSource';
+import { field } from './expressions/AttributeFilter';
 
 describe('AudiomSource', () => {
   describe('constructor', () => {
     it('assigns all config properties', () => {
+      const whereExpr = field('type').eq('building');
       const src = new AudiomSource({
         source: 'mySource',
         type: SourceType.ESRI,
@@ -11,7 +13,7 @@ describe('AudiomSource', () => {
         name: 'My Source',
         url: 'https://example.com/service',
         rules: '/rules.json',
-        where: "type='building'",
+        where: whereExpr,
         additionalParams: { foo: 'bar' }
       });
 
@@ -21,7 +23,7 @@ describe('AudiomSource', () => {
       expect(src.name).toBe('My Source');
       expect(src.url).toBe('https://example.com/service');
       expect(src.rules).toBe('/rules.json');
-      expect(src.where).toBe("type='building'");
+      expect(src.where).toBe(whereExpr);
       expect(src.additionalParams).toEqual({ foo: 'bar' });
     });
 
@@ -62,13 +64,14 @@ describe('AudiomSource', () => {
 
   describe('fromEsri', () => {
     it('creates an ESRI source', () => {
+      const whereExpr = field('type').eq('commercial');
       const src = AudiomSource.fromEsri({
         source: 'buildings',
         url: 'https://services.arcgis.com/layer',
         name: 'Buildings',
         mapType: MapType.Indoor,
         rules: '/rules.json',
-        where: "type='commercial'"
+        where: whereExpr
       });
 
       expect(src.source).toBe('buildings');
@@ -77,7 +80,7 @@ describe('AudiomSource', () => {
       expect(src.name).toBe('Buildings');
       expect(src.mapType).toBe(MapType.Indoor);
       expect(src.rules).toBe('/rules.json');
-      expect(src.where).toBe("type='commercial'");
+      expect(src.where).toBe(whereExpr);
     });
 
     it('works with only required fields', () => {
@@ -101,7 +104,7 @@ describe('AudiomSource', () => {
         name: 'Display Name',
         url: 'https://example.com/data',
         rules: '/rules.json',
-        where: "status='active'"
+        where: field('status').eq('active')
       });
 
       const params = src.toQueryParams();
@@ -110,7 +113,7 @@ describe('AudiomSource', () => {
       expect(params['mySource.name']).toBe('Display Name');
       expect(params['mySource.url']).toBe('https://example.com/data');
       expect(params['mySource.rules']).toBe('/rules.json');
-      expect(params['mySource.where']).toBe("status='active'");
+      expect(params['mySource.where']).toBe("status = 'active'");
     });
 
     it('includes additionalParams with namespaced keys', () => {

--- a/src/AudiomSource.test.ts
+++ b/src/AudiomSource.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { AudiomSource, SourceType, MapType } from './AudiomSource';
 import { field } from './expressions/AttributeFilter';
+import { orderBy, SortOrder } from './expressions/QueryOptions';
 
 describe('AudiomSource', () => {
   describe('constructor', () => {
@@ -126,6 +127,65 @@ describe('AudiomSource', () => {
       expect(params['src.custom']).toBe('value');
       expect(params['src.count']).toBe('5');
       expect(params['src.enabled']).toBe('true');
+    });
+
+    it('serializes outFields as comma-separated list', () => {
+      const src = new AudiomSource({
+        source: 'layer',
+        outFields: ['name', 'population', 'state']
+      });
+      const params = src.toQueryParams();
+      expect(params['layer.outFields']).toBe('name,population,state');
+    });
+
+    it('serializes wildcard outFields', () => {
+      const src = new AudiomSource({
+        source: 'layer',
+        outFields: ['*']
+      });
+      const params = src.toQueryParams();
+      expect(params['layer.outFields']).toBe('*');
+    });
+
+    it('omits outFields when empty array', () => {
+      const src = new AudiomSource({
+        source: 'layer',
+        outFields: []
+      });
+      const params = src.toQueryParams();
+      expect(params['layer.outFields']).toBeUndefined();
+    });
+
+    it('serializes orderByFields with sort direction', () => {
+      const src = new AudiomSource({
+        source: 'layer',
+        orderByFields: [
+          orderBy('name'),
+          orderBy('population', SortOrder.Descending)
+        ]
+      });
+      const params = src.toQueryParams();
+      expect(params['layer.orderByFields']).toBe('name ASC, population DESC');
+    });
+
+    it('serializes pagination with count only', () => {
+      const src = new AudiomSource({
+        source: 'layer',
+        pagination: { count: 50 }
+      });
+      const params = src.toQueryParams();
+      expect(params['layer.resultRecordCount']).toBe('50');
+      expect(params['layer.resultOffset']).toBeUndefined();
+    });
+
+    it('serializes pagination with count and offset', () => {
+      const src = new AudiomSource({
+        source: 'layer',
+        pagination: { count: 25, offset: 100 }
+      });
+      const params = src.toQueryParams();
+      expect(params['layer.resultRecordCount']).toBe('25');
+      expect(params['layer.resultOffset']).toBe('100');
     });
   });
 });

--- a/src/AudiomSource.ts
+++ b/src/AudiomSource.ts
@@ -2,6 +2,7 @@ import { Expression } from './expressions/Expression';
 import { toString } from './expressions/Serialize';
 import { SpatialFilter } from './expressions/SpatialFilter';
 import { TimeInstant, TimeExtent } from './expressions/TemporalFilter';
+import { OrderByField, PaginationOptions, orderByFieldsToString } from './expressions/QueryOptions';
 
 /**
  * Map type for rendering sources
@@ -74,6 +75,25 @@ export interface IAudiomSource {
   time?: TimeInstant | TimeExtent;
 
   /**
+   * Limit which fields/properties are returned in results.
+   * Pass `['*']` to return all fields.
+   *
+   * @see https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-layer/
+   */
+  outFields?: string[];
+
+  /**
+   * Sort results by one or more fields.
+   * Use `orderBy('field', SortOrder.Descending)` to build entries.
+   */
+  orderByFields?: OrderByField[];
+
+  /**
+   * Pagination options: limit and offset for result sets.
+   */
+  pagination?: PaginationOptions;
+
+  /**
    * Additional custom parameters for the source
    */
   additionalParams?: Record<string, string | number | boolean>;
@@ -92,6 +112,9 @@ export class AudiomSource implements IAudiomSource {
   where?: Expression;
   spatialFilter?: SpatialFilter;
   time?: TimeInstant | TimeExtent;
+  outFields?: string[];
+  orderByFields?: OrderByField[];
+  pagination?: PaginationOptions;
   additionalParams?: Record<string, string | number | boolean>;
 
   constructor(config: IAudiomSource) {
@@ -104,6 +127,9 @@ export class AudiomSource implements IAudiomSource {
     this.where = config.where;
     this.spatialFilter = config.spatialFilter;
     this.time = config.time;
+    this.outFields = config.outFields;
+    this.orderByFields = config.orderByFields;
+    this.pagination = config.pagination;
     this.additionalParams = config.additionalParams;
   }
 
@@ -137,6 +163,9 @@ export class AudiomSource implements IAudiomSource {
     where?: Expression;
     spatialFilter?: SpatialFilter;
     time?: TimeInstant | TimeExtent;
+    outFields?: string[];
+    orderByFields?: OrderByField[];
+    pagination?: PaginationOptions;
   }): AudiomSource {
     return new AudiomSource({
       source: config.source,
@@ -147,7 +176,10 @@ export class AudiomSource implements IAudiomSource {
       rules: config.rules,
       where: config.where,
       spatialFilter: config.spatialFilter,
-      time: config.time
+      time: config.time,
+      outFields: config.outFields,
+      orderByFields: config.orderByFields,
+      pagination: config.pagination,
     });
   }
 
@@ -186,6 +218,18 @@ export class AudiomSource implements IAudiomSource {
     }
     if (this.time) {
       params[`${sourceName}.time`] = this.time.toQueryParam();
+    }
+    if (this.outFields && this.outFields.length > 0) {
+      params[`${sourceName}.outFields`] = this.outFields.join(',');
+    }
+    if (this.orderByFields && this.orderByFields.length > 0) {
+      params[`${sourceName}.orderByFields`] = orderByFieldsToString(this.orderByFields);
+    }
+    if (this.pagination) {
+      params[`${sourceName}.resultRecordCount`] = String(this.pagination.count);
+      if (this.pagination.offset !== undefined) {
+        params[`${sourceName}.resultOffset`] = String(this.pagination.offset);
+      }
     }
     if (this.additionalParams) {
       Object.entries(this.additionalParams).forEach(([key, value]) => {

--- a/src/AudiomSource.ts
+++ b/src/AudiomSource.ts
@@ -1,3 +1,8 @@
+import { Expression } from './expressions/Expression';
+import { toString } from './expressions/Serialize';
+import { SpatialFilter } from './expressions/SpatialFilter';
+import { TimeInstant, TimeExtent } from './expressions/TemporalFilter';
+
 /**
  * Map type for rendering sources
  */
@@ -52,9 +57,21 @@ export interface IAudiomSource {
   rules?: string;
 
   /**
-   * Where clause / definition expression to filter features
+   * Where clause / definition expression to filter features.
+   * Use `parse()` to convert raw SQL strings, or the fluent builder
+   * (`field('name').eq('value')`) to construct expressions.
    */
-  where?: string;
+  where?: Expression;
+
+  /**
+   * Spatial filter for geometry-based queries (Esri sources)
+   */
+  spatialFilter?: SpatialFilter;
+
+  /**
+   * Temporal filter for time-aware layers (Esri sources)
+   */
+  time?: TimeInstant | TimeExtent;
 
   /**
    * Additional custom parameters for the source
@@ -72,7 +89,9 @@ export class AudiomSource implements IAudiomSource {
   name?: string;
   url?: string;
   rules?: string;
-  where?: string;
+  where?: Expression;
+  spatialFilter?: SpatialFilter;
+  time?: TimeInstant | TimeExtent;
   additionalParams?: Record<string, string | number | boolean>;
 
   constructor(config: IAudiomSource) {
@@ -83,6 +102,8 @@ export class AudiomSource implements IAudiomSource {
     this.url = config.url;
     this.rules = config.rules;
     this.where = config.where;
+    this.spatialFilter = config.spatialFilter;
+    this.time = config.time;
     this.additionalParams = config.additionalParams;
   }
 
@@ -113,7 +134,9 @@ export class AudiomSource implements IAudiomSource {
     name?: string;
     mapType?: MapType;
     rules?: string;
-    where?: string;
+    where?: Expression;
+    spatialFilter?: SpatialFilter;
+    time?: TimeInstant | TimeExtent;
   }): AudiomSource {
     return new AudiomSource({
       source: config.source,
@@ -122,7 +145,9 @@ export class AudiomSource implements IAudiomSource {
       name: config.name,
       mapType: config.mapType,
       rules: config.rules,
-      where: config.where
+      where: config.where,
+      spatialFilter: config.spatialFilter,
+      time: config.time
     });
   }
 
@@ -151,7 +176,16 @@ export class AudiomSource implements IAudiomSource {
       params[`${sourceName}.rules`] = this.rules;
     }
     if (this.where) {
-      params[`${sourceName}.where`] = this.where;
+      params[`${sourceName}.where`] = toString(this.where);
+    }
+    if (this.spatialFilter) {
+      const spatialParams = this.spatialFilter.toQueryParams();
+      Object.entries(spatialParams).forEach(([key, value]) => {
+        params[`${sourceName}.${key}`] = value;
+      });
+    }
+    if (this.time) {
+      params[`${sourceName}.time`] = this.time.toQueryParam();
     }
     if (this.additionalParams) {
       Object.entries(this.additionalParams).forEach(([key, value]) => {

--- a/src/README.md
+++ b/src/README.md
@@ -144,6 +144,173 @@ const config = AudiomEmbedConfig.dynamic({
 // Produces: &filters=walls,poi,building&filterMode=global
 ```
 
+## Expression Filters (WHERE Clauses)
+
+For sources that support query filtering (e.g., Esri feature services), you can build typed WHERE clause expressions using the fluent builder API, or parse raw SQL strings.
+
+### Building Expressions
+
+```typescript
+import { field, and, or, not, raw, toString, parse } from 'audiom-embedder';
+
+// Simple comparison
+const expr = field('status').eq('active');
+// → status = 'active'
+
+// Numeric comparisons
+field('height').gt(100);       // height > 100
+field('floors').gte(10);       // floors >= 10
+field('population').lt(5000);  // population < 5000
+field('score').lte(99);        // score <= 99
+field('type').neq('deleted');  // type <> 'deleted'
+```
+
+### Compound Expressions
+
+```typescript
+// AND / OR
+const expr = and(
+  field('type').eq('building'),
+  or(
+    field('height').gt(100),
+    field('floors').gte(10)
+  )
+);
+toString(expr);
+// → type = 'building' AND (height > 100 OR floors >= 10)
+
+// NOT
+toString(not(field('status').eq('demolished')));
+// → NOT (status = 'demolished')
+```
+
+### Pattern Matching, Sets, and Ranges
+
+```typescript
+// LIKE / NOT LIKE
+field('name').like('Main%');        // name LIKE 'Main%'
+field('name').notLike('%test%');     // name NOT LIKE '%test%'
+
+// IN / NOT IN
+field('category').in(['residential', 'commercial']);
+// → category IN ('residential', 'commercial')
+
+field('id').notIn([1, 2, 3]);
+// → id NOT IN (1, 2, 3)
+
+// BETWEEN / NOT BETWEEN
+field('population').between(1000, 50000);
+// → population BETWEEN 1000 AND 50000
+
+// IS NULL / IS NOT NULL
+field('notes').isNull();       // notes IS NULL
+field('notes').isNotNull();    // notes IS NOT NULL
+```
+
+### Date Expressions
+
+```typescript
+// Date values serialize as TIMESTAMP literals
+const cutoff = new Date(Date.UTC(2024, 0, 15, 10, 30, 0));
+toString(field('created').gt(cutoff));
+// → created > TIMESTAMP '2024-01-15 10:30:00'
+```
+
+### Raw SQL Escape Hatch
+
+For vendor-specific syntax not covered by the typed builder:
+
+```typescript
+// ⚠️ Never pass untrusted user input to raw()
+const expr = raw("position(current_user in workersfield) > 0");
+toString(expr);
+// → position(current_user in workersfield) > 0
+```
+
+### Parsing SQL Strings
+
+Parse existing SQL WHERE clauses into the typed AST:
+
+```typescript
+const expr = parse("type = 'building' AND status = 'active'");
+// → LogicalExpr { op: 'AND', children: [ComparisonExpr, ComparisonExpr] }
+
+// Round-trip: parse then serialize
+toString(parse("name LIKE 'Main%'"));
+// → name LIKE 'Main%'
+
+// Unparseable syntax falls back to RawExpr instead of throwing
+parse("SOME_FUNC(a, b)");
+// → RawExpr { sql: 'SOME_FUNC(a, b)' }
+```
+
+### Applying Expressions to Sources
+
+```typescript
+const source = AudiomSource.fromEsri({
+  source: 'buildings',
+  url: 'https://services.arcgis.com/.../FeatureServer/0',
+  where: and(
+    field('status').eq('active'),
+    field('floors').gte(3)
+  )
+});
+// Serializes to: buildings.where=status%20%3D%20'active'%20AND%20floors%20%3E%3D%203
+```
+
+### Spatial Filters
+
+Constrain queries to features with a specific spatial relationship to an input geometry:
+
+```typescript
+import { SpatialFilter, GeometryType, DistanceUnit } from 'audiom-embedder';
+
+// Bounding box intersection
+const bbox = SpatialFilter.fromEnvelope(-123, 37, -122, 38, 4326);
+
+// Point with distance buffer
+const nearby = SpatialFilter.withinDistance(
+  { x: -122.4, y: 37.8 },
+  GeometryType.Point,
+  1000,
+  DistanceUnit.Meter
+);
+
+// Apply to a source
+const source = AudiomSource.fromEsri({
+  source: 'poi',
+  url: 'https://services.arcgis.com/.../FeatureServer/0',
+  spatialFilter: nearby
+});
+```
+
+### Temporal Filters
+
+Filter time-aware layers by instant or range:
+
+```typescript
+import { TimeInstant, TimeExtent } from 'audiom-embedder';
+
+// Single point in time
+const instant = TimeInstant.fromDate(new Date(Date.UTC(2024, 6, 1)));
+
+// Time range
+const range = TimeExtent.fromDates(
+  new Date(Date.UTC(2024, 0, 1)),
+  new Date(Date.UTC(2024, 11, 31))
+);
+
+// Open-ended range (from a date to present)
+const since = TimeExtent.fromDates(new Date(Date.UTC(2024, 0, 1)), null);
+
+// Apply to a source
+const source = AudiomSource.fromEsri({
+  source: 'events',
+  url: 'https://services.arcgis.com/.../FeatureServer/0',
+  time: range
+});
+```
+
 ## PostMessage API
 
 The PostMessage API enables bidirectional communication between your app and an embedded Audiom map. It must be enabled by specifying `allowedOrigins`.

--- a/src/expressions/AttributeFilter.test.ts
+++ b/src/expressions/AttributeFilter.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { field, and, or, not, raw, FieldRef } from './AttributeFilter';
+import { ComparisonOp, LogicalOp } from './Expression';
+
+describe('field()', () => {
+  it('returns a FieldRef', () => {
+    expect(field('status')).toBeInstanceOf(FieldRef);
+  });
+});
+
+describe('FieldRef', () => {
+  const f = field('status');
+
+  it('eq() creates a comparison expression', () => {
+    const expr = f.eq('active');
+    expect(expr).toEqual({
+      type: 'comparison',
+      field: 'status',
+      op: ComparisonOp.Equal,
+      value: 'active'
+    });
+  });
+
+  it('neq()', () => {
+    expect(f.neq('deleted')).toMatchObject({ op: ComparisonOp.NotEqual, value: 'deleted' });
+  });
+
+  it('lt()', () => {
+    expect(field('height').lt(100)).toMatchObject({ op: ComparisonOp.LessThan, value: 100 });
+  });
+
+  it('gt()', () => {
+    expect(field('height').gt(50)).toMatchObject({ op: ComparisonOp.GreaterThan, value: 50 });
+  });
+
+  it('lte()', () => {
+    expect(field('height').lte(200)).toMatchObject({ op: ComparisonOp.LessThanOrEqual, value: 200 });
+  });
+
+  it('gte()', () => {
+    expect(field('height').gte(10)).toMatchObject({ op: ComparisonOp.GreaterThanOrEqual, value: 10 });
+  });
+
+  it('like()', () => {
+    const expr = f.like('active%');
+    expect(expr).toEqual({ type: 'like', field: 'status', pattern: 'active%' });
+  });
+
+  it('notLike()', () => {
+    const expr = f.notLike('deleted%');
+    expect(expr).toEqual({ type: 'like', field: 'status', pattern: 'deleted%', not: true });
+  });
+
+  it('in()', () => {
+    const expr = field('type').in(['a', 'b']);
+    expect(expr).toEqual({ type: 'in', field: 'type', values: ['a', 'b'] });
+  });
+
+  it('notIn()', () => {
+    const expr = field('type').notIn(['x']);
+    expect(expr).toEqual({ type: 'in', field: 'type', values: ['x'], not: true });
+  });
+
+  it('between()', () => {
+    const expr = field('pop').between(100, 999);
+    expect(expr).toEqual({ type: 'between', field: 'pop', low: 100, high: 999 });
+  });
+
+  it('notBetween()', () => {
+    const expr = field('pop').notBetween(0, 10);
+    expect(expr).toEqual({ type: 'between', field: 'pop', low: 0, high: 10, not: true });
+  });
+
+  it('isNull()', () => {
+    expect(f.isNull()).toEqual({ type: 'isNull', field: 'status' });
+  });
+
+  it('isNotNull()', () => {
+    expect(f.isNotNull()).toEqual({ type: 'isNull', field: 'status', not: true });
+  });
+});
+
+describe('and()', () => {
+  it('creates a logical AND expression', () => {
+    const a = field('x').eq(1);
+    const b = field('y').eq(2);
+    const expr = and(a, b);
+    expect(expr).toEqual({
+      type: 'logical',
+      op: LogicalOp.And,
+      children: [a, b]
+    });
+  });
+});
+
+describe('or()', () => {
+  it('creates a logical OR expression', () => {
+    const a = field('x').eq(1);
+    const b = field('y').eq(2);
+    expect(or(a, b).op).toBe(LogicalOp.Or);
+  });
+});
+
+describe('not()', () => {
+  it('wraps an expression in NOT', () => {
+    const child = field('x').eq(1);
+    expect(not(child)).toEqual({ type: 'not', child });
+  });
+});
+
+describe('raw()', () => {
+  it('wraps arbitrary SQL', () => {
+    expect(raw("FUNC(a)")).toEqual({ type: 'raw', sql: 'FUNC(a)' });
+  });
+});

--- a/src/expressions/AttributeFilter.ts
+++ b/src/expressions/AttributeFilter.ts
@@ -1,0 +1,154 @@
+/**
+ * Fluent builder API for constructing typed WHERE clause expressions.
+ *
+ * @example
+ * ```ts
+ * import { field, and, or, not, raw } from './expressions';
+ *
+ * // Simple comparison
+ * field('status').eq('active')
+ *
+ * // Compound expression
+ * and(
+ *   field('type').eq('building'),
+ *   or(
+ *     field('height').gt(100),
+ *     field('floors').gte(10)
+ *   )
+ * )
+ *
+ * // Pattern matching and set membership
+ * field('name').like('Main%')
+ * field('category').in(['residential', 'commercial'])
+ *
+ * // Range and null checks
+ * field('population').between(1000, 50000)
+ * field('notes').isNotNull()
+ *
+ * // Escape hatch for vendor-specific SQL
+ * raw("position(current_user in workersfield) > 0")
+ * ```
+ *
+ * @see https://developers.arcgis.com/rest/services-reference/enterprise/sql-reference-for-query-expressions-used-in-the-arcgis-rest-api/
+ */
+
+import {
+  Expression,
+  ExpressionType,
+  ComparisonOp,
+  LogicalOp,
+  LiteralValue,
+  ComparisonExpr,
+  LogicalExpr,
+  NotExpr,
+  LikeExpr,
+  InExpr,
+  BetweenExpr,
+  IsNullExpr,
+  RawExpr
+} from './Expression';
+
+// ── Field reference builder ─────────────────────────────────────────
+
+export class FieldRef {
+  constructor(private readonly name: string) {}
+
+  eq(value: LiteralValue): ComparisonExpr {
+    return { type: ExpressionType.Comparison, field: this.name, op: ComparisonOp.Equal, value };
+  }
+
+  neq(value: LiteralValue): ComparisonExpr {
+    return { type: ExpressionType.Comparison, field: this.name, op: ComparisonOp.NotEqual, value };
+  }
+
+  lt(value: LiteralValue): ComparisonExpr {
+    return { type: ExpressionType.Comparison, field: this.name, op: ComparisonOp.LessThan, value };
+  }
+
+  gt(value: LiteralValue): ComparisonExpr {
+    return { type: ExpressionType.Comparison, field: this.name, op: ComparisonOp.GreaterThan, value };
+  }
+
+  lte(value: LiteralValue): ComparisonExpr {
+    return { type: ExpressionType.Comparison, field: this.name, op: ComparisonOp.LessThanOrEqual, value };
+  }
+
+  gte(value: LiteralValue): ComparisonExpr {
+    return { type: ExpressionType.Comparison, field: this.name, op: ComparisonOp.GreaterThanOrEqual, value };
+  }
+
+  /**
+   * SQL LIKE pattern matching.
+   * Use `%` for any characters, `_` for a single character.
+   */
+  like(pattern: string): LikeExpr {
+    return { type: ExpressionType.Like, field: this.name, pattern };
+  }
+
+  notLike(pattern: string): LikeExpr {
+    return { type: ExpressionType.Like, field: this.name, pattern, not: true };
+  }
+
+  in(values: LiteralValue[]): InExpr {
+    return { type: ExpressionType.In, field: this.name, values };
+  }
+
+  notIn(values: LiteralValue[]): InExpr {
+    return { type: ExpressionType.In, field: this.name, values, not: true };
+  }
+
+  between(low: LiteralValue, high: LiteralValue): BetweenExpr {
+    return { type: ExpressionType.Between, field: this.name, low, high };
+  }
+
+  notBetween(low: LiteralValue, high: LiteralValue): BetweenExpr {
+    return { type: ExpressionType.Between, field: this.name, low, high, not: true };
+  }
+
+  isNull(): IsNullExpr {
+    return { type: ExpressionType.IsNull, field: this.name };
+  }
+
+  isNotNull(): IsNullExpr {
+    return { type: ExpressionType.IsNull, field: this.name, not: true };
+  }
+}
+
+// ── Top-level builder functions ─────────────────────────────────────
+
+/**
+ * Start building an expression by referencing a field name.
+ */
+export function field(name: string): FieldRef {
+  return new FieldRef(name);
+}
+
+/**
+ * Combine expressions with AND.
+ */
+export function and(...children: Expression[]): LogicalExpr {
+  return { type: ExpressionType.Logical, op: LogicalOp.And, children };
+}
+
+/**
+ * Combine expressions with OR.
+ */
+export function or(...children: Expression[]): LogicalExpr {
+  return { type: ExpressionType.Logical, op: LogicalOp.Or, children };
+}
+
+/**
+ * Negate an expression with NOT.
+ */
+export function not(child: Expression): NotExpr {
+  return { type: ExpressionType.Not, child };
+}
+
+/**
+ * Escape hatch: embed a raw SQL string as an expression node.
+ * Use this for vendor-specific syntax not covered by the typed builder
+ * (e.g., `CURRENT_USER`, `position()`, Esri-specific functions).
+ */
+export function raw(sql: string): RawExpr {
+  return { type: ExpressionType.Raw, sql };
+}

--- a/src/expressions/AttributeFilter.ts
+++ b/src/expressions/AttributeFilter.ts
@@ -148,6 +148,9 @@ export function not(child: Expression): NotExpr {
  * Escape hatch: embed a raw SQL string as an expression node.
  * Use this for vendor-specific syntax not covered by the typed builder
  * (e.g., `CURRENT_USER`, `position()`, Esri-specific functions).
+ *
+ * **Security:** The SQL string is emitted verbatim with no escaping.
+ * Never pass untrusted / user-supplied input directly to this function.
  */
 export function raw(sql: string): RawExpr {
   return { type: ExpressionType.Raw, sql };

--- a/src/expressions/Expression.test.ts
+++ b/src/expressions/Expression.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ComparisonOp,
+  LogicalOp,
+  ExpressionType,
+} from './Expression';
+import type {
+  ComparisonExpr,
+  LogicalExpr,
+  NotExpr,
+  LikeExpr,
+  InExpr,
+  BetweenExpr,
+  IsNullExpr,
+  RawExpr,
+  Expression,
+} from './Expression';
+
+describe('Expression AST types', () => {
+  it('ComparisonExpr has the correct shape', () => {
+    const expr: ComparisonExpr = {
+      type: ExpressionType.Comparison,
+      field: 'status',
+      op: ComparisonOp.Equal,
+      value: 'active'
+    };
+    expect(expr.type).toBe(ExpressionType.Comparison);
+    expect(expr.op).toBe('=');
+  });
+
+  it('LogicalExpr combines children', () => {
+    const left: ComparisonExpr = { type: ExpressionType.Comparison, field: 'a', op: ComparisonOp.LessThan, value: 5 };
+    const right: ComparisonExpr = { type: ExpressionType.Comparison, field: 'b', op: ComparisonOp.GreaterThan, value: 10 };
+    const expr: LogicalExpr = { type: ExpressionType.Logical, op: LogicalOp.And, children: [left, right] };
+    expect(expr.children).toHaveLength(2);
+    expect(expr.op).toBe('AND');
+  });
+
+  it('NotExpr wraps a child', () => {
+    const child: ComparisonExpr = { type: ExpressionType.Comparison, field: 'x', op: ComparisonOp.Equal, value: 1 };
+    const expr: NotExpr = { type: ExpressionType.Not, child };
+    expect(expr.type).toBe(ExpressionType.Not);
+    expect(expr.child).toBe(child);
+  });
+
+  it('LikeExpr supports optional not flag', () => {
+    const expr: LikeExpr = { type: ExpressionType.Like, field: 'name', pattern: 'Main%' };
+    expect(expr.not).toBeUndefined();
+
+    const negated: LikeExpr = { type: ExpressionType.Like, field: 'name', pattern: 'Main%', not: true };
+    expect(negated.not).toBe(true);
+  });
+
+  it('InExpr supports value lists', () => {
+    const expr: InExpr = { type: ExpressionType.In, field: 'type', values: ['a', 'b', 'c'] };
+    expect(expr.values).toHaveLength(3);
+  });
+
+  it('BetweenExpr stores low and high', () => {
+    const expr: BetweenExpr = { type: ExpressionType.Between, field: 'pop', low: 100, high: 999 };
+    expect(expr.low).toBe(100);
+    expect(expr.high).toBe(999);
+  });
+
+  it('IsNullExpr supports not flag', () => {
+    const expr: IsNullExpr = { type: ExpressionType.IsNull, field: 'notes' };
+    expect(expr.not).toBeUndefined();
+
+    const notNull: IsNullExpr = { type: ExpressionType.IsNull, field: 'notes', not: true };
+    expect(notNull.not).toBe(true);
+  });
+
+  it('RawExpr holds arbitrary SQL', () => {
+    const expr: RawExpr = { type: ExpressionType.Raw, sql: 'FUNC(a, b)' };
+    expect(expr.sql).toBe('FUNC(a, b)');
+  });
+
+  it('Expression union can be discriminated by type', () => {
+    const expr: Expression = { type: ExpressionType.Comparison, field: 'x', op: ComparisonOp.Equal, value: 1 };
+    switch (expr.type) {
+      case ExpressionType.Comparison:
+        expect(expr.field).toBe('x');
+        break;
+      default:
+        expect.unreachable('Expected comparison');
+    }
+  });
+});
+
+describe('ComparisonOp enum', () => {
+  it('maps to SQL operator strings', () => {
+    expect(ComparisonOp.Equal).toBe('=');
+    expect(ComparisonOp.NotEqual).toBe('<>');
+    expect(ComparisonOp.LessThan).toBe('<');
+    expect(ComparisonOp.GreaterThan).toBe('>');
+    expect(ComparisonOp.LessThanOrEqual).toBe('<=');
+    expect(ComparisonOp.GreaterThanOrEqual).toBe('>=');
+  });
+});
+
+describe('LogicalOp enum', () => {
+  it('maps to SQL keywords', () => {
+    expect(LogicalOp.And).toBe('AND');
+    expect(LogicalOp.Or).toBe('OR');
+  });
+});

--- a/src/expressions/Expression.ts
+++ b/src/expressions/Expression.ts
@@ -1,0 +1,115 @@
+/**
+ * Typed expression AST for building feature query filters.
+ *
+ * Supports the SQL-92 subset used by Esri feature services, plus extensions
+ * for spatial and temporal filtering.
+ *
+ * @see https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-layer/
+ * @see https://developers.arcgis.com/rest/services-reference/enterprise/sql-reference-for-query-expressions-used-in-the-arcgis-rest-api/
+ * @see https://docs.ogc.org/is/21-065r2/21-065r2.html (OGC CQL2, informational)
+ */
+
+// ── Comparison operators ────────────────────────────────────────────
+
+export enum ComparisonOp {
+  Equal = '=',
+  NotEqual = '<>',
+  LessThan = '<',
+  GreaterThan = '>',
+  LessThanOrEqual = '<=',
+  GreaterThanOrEqual = '>='
+}
+
+// ── Logical operators ───────────────────────────────────────────────
+
+export enum LogicalOp {
+  And = 'AND',
+  Or = 'OR'
+}
+
+// ── Expression node types ───────────────────────────────────────────
+
+export enum ExpressionType {
+  Comparison = 'comparison',
+  Logical = 'logical',
+  Not = 'not',
+  Like = 'like',
+  In = 'in',
+  Between = 'between',
+  IsNull = 'isNull',
+  Raw = 'raw'
+}
+
+// ── Literal value types allowed in expressions ──────────────────────
+
+export type LiteralValue = string | number | boolean | Date | null;
+
+// ── AST node types (discriminated union) ────────────────────────────
+
+export interface ComparisonExpr {
+  type: ExpressionType.Comparison;
+  field: string;
+  op: ComparisonOp;
+  value: LiteralValue;
+}
+
+export interface LogicalExpr {
+  type: ExpressionType.Logical;
+  op: LogicalOp;
+  children: Expression[];
+}
+
+export interface NotExpr {
+  type: ExpressionType.Not;
+  child: Expression;
+}
+
+export interface LikeExpr {
+  type: ExpressionType.Like;
+  field: string;
+  pattern: string;
+  not?: boolean;
+}
+
+export interface InExpr {
+  type: ExpressionType.In;
+  field: string;
+  values: LiteralValue[];
+  not?: boolean;
+}
+
+export interface BetweenExpr {
+  type: ExpressionType.Between;
+  field: string;
+  low: LiteralValue;
+  high: LiteralValue;
+  not?: boolean;
+}
+
+export interface IsNullExpr {
+  type: ExpressionType.IsNull;
+  field: string;
+  not?: boolean;
+}
+
+/**
+ * Escape hatch for raw SQL strings that can't be represented by the typed AST.
+ * Use `raw(sql)` from AttributeFilter to create these.
+ */
+export interface RawExpr {
+  type: ExpressionType.Raw;
+  sql: string;
+}
+
+/**
+ * Discriminated union of all expression node types.
+ */
+export type Expression =
+  | ComparisonExpr
+  | LogicalExpr
+  | NotExpr
+  | LikeExpr
+  | InExpr
+  | BetweenExpr
+  | IsNullExpr
+  | RawExpr;

--- a/src/expressions/Parse.test.ts
+++ b/src/expressions/Parse.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from 'vitest';
+import { parse } from './parsing';
+import { toString } from './Serialize';
+
+describe('parse', () => {
+  describe('comparison', () => {
+    it('parses string equality', () => {
+      const expr = parse("status = 'active'");
+      expect(expr).toEqual({
+        type: 'comparison',
+        field: 'status',
+        op: '=',
+        value: 'active'
+      });
+    });
+
+    it('parses numeric comparison', () => {
+      const expr = parse('height > 100');
+      expect(expr).toEqual({
+        type: 'comparison',
+        field: 'height',
+        op: '>',
+        value: 100
+      });
+    });
+
+    it('parses <> operator', () => {
+      const expr = parse("type <> 'deleted'");
+      expect(expr).toMatchObject({ op: '<>', value: 'deleted' });
+    });
+
+    it('parses <= and >= operators', () => {
+      expect(parse('x <= 10')).toMatchObject({ op: '<=', value: 10 });
+      expect(parse('x >= 5')).toMatchObject({ op: '>=', value: 5 });
+    });
+
+    it('parses NULL literal', () => {
+      const expr = parse('x = NULL');
+      expect(expr).toMatchObject({ type: 'comparison', value: null });
+    });
+
+    it('parses decimal numbers', () => {
+      const expr = parse('x > 3.14');
+      expect(expr).toMatchObject({ value: 3.14 });
+    });
+
+    it('parses escaped quotes in strings', () => {
+      const expr = parse("name = 'O''Brien'");
+      expect(expr).toMatchObject({ type: 'comparison', value: "O'Brien" });
+    });
+
+    it('parses TIMESTAMP literal', () => {
+      const expr = parse("created > TIMESTAMP '2024-01-15 10:30:00'");
+      expect(expr).toMatchObject({ type: 'comparison', field: 'created', op: '>' });
+      if (expr.type === 'comparison' && expr.value instanceof Date) {
+        expect(expr.value.getUTCFullYear()).toBe(2024);
+        expect(expr.value.getUTCMonth()).toBe(0);
+        expect(expr.value.getUTCDate()).toBe(15);
+      } else {
+        expect.unreachable('Expected Date value');
+      }
+    });
+  });
+
+  describe('logical', () => {
+    it('parses AND', () => {
+      const expr = parse("a = 1 AND b = 2");
+      expect(expr).toMatchObject({
+        type: 'logical',
+        op: 'AND',
+        children: [
+          { type: 'comparison', field: 'a', value: 1 },
+          { type: 'comparison', field: 'b', value: 2 }
+        ]
+      });
+    });
+
+    it('parses OR', () => {
+      const expr = parse("a = 1 OR b = 2");
+      expect(expr).toMatchObject({ type: 'logical', op: 'OR' });
+    });
+
+    it('respects AND/OR precedence', () => {
+      // a = 1 OR b = 2 AND c = 3 should be: a = 1 OR (b = 2 AND c = 3)
+      const expr = parse("a = 1 OR b = 2 AND c = 3");
+      expect(expr.type).toBe('logical');
+      if (expr.type === 'logical') {
+        expect(expr.op).toBe('OR');
+        expect(expr.children[0]).toMatchObject({ field: 'a' });
+        expect(expr.children[1]).toMatchObject({ type: 'logical', op: 'AND' });
+      }
+    });
+
+    it('flattens chained same-operators', () => {
+      const expr = parse("a = 1 AND b = 2 AND c = 3");
+      if (expr.type === 'logical') {
+        expect(expr.children).toHaveLength(3);
+      }
+    });
+  });
+
+  describe('NOT', () => {
+    it('parses NOT prefix', () => {
+      const expr = parse("NOT status = 'deleted'");
+      expect(expr).toMatchObject({
+        type: 'not',
+        child: { type: 'comparison', field: 'status', value: 'deleted' }
+      });
+    });
+  });
+
+  describe('LIKE', () => {
+    it('parses LIKE expression', () => {
+      const expr = parse("name LIKE 'Main%'");
+      expect(expr).toEqual({ type: 'like', field: 'name', pattern: 'Main%' });
+    });
+
+    it('parses NOT LIKE expression', () => {
+      const expr = parse("name NOT LIKE '%test%'");
+      expect(expr).toEqual({ type: 'like', field: 'name', pattern: '%test%', not: true });
+    });
+  });
+
+  describe('IN', () => {
+    it('parses IN with string values', () => {
+      const expr = parse("type IN ('a', 'b', 'c')");
+      expect(expr).toMatchObject({
+        type: 'in',
+        field: 'type',
+        values: ['a', 'b', 'c']
+      });
+    });
+
+    it('parses NOT IN with numeric values', () => {
+      const expr = parse("id NOT IN (1, 2, 3)");
+      expect(expr).toMatchObject({
+        type: 'in',
+        field: 'id',
+        values: [1, 2, 3],
+        not: true
+      });
+    });
+  });
+
+  describe('BETWEEN', () => {
+    it('parses BETWEEN', () => {
+      const expr = parse("pop BETWEEN 1000 AND 50000");
+      expect(expr).toMatchObject({
+        type: 'between',
+        field: 'pop',
+        low: 1000,
+        high: 50000
+      });
+    });
+
+    it('parses NOT BETWEEN', () => {
+      const expr = parse("pop NOT BETWEEN 0 AND 10");
+      expect(expr).toMatchObject({
+        type: 'between',
+        field: 'pop',
+        low: 0,
+        high: 10,
+        not: true
+      });
+    });
+  });
+
+  describe('IS NULL', () => {
+    it('parses IS NULL', () => {
+      const expr = parse("notes IS NULL");
+      expect(expr).toEqual({ type: 'isNull', field: 'notes', not: false });
+    });
+
+    it('parses IS NOT NULL', () => {
+      const expr = parse("notes IS NOT NULL");
+      expect(expr).toEqual({ type: 'isNull', field: 'notes', not: true });
+    });
+  });
+
+  describe('parenthesized groups', () => {
+    it('parses parenthesized subexpression', () => {
+      const expr = parse("a = 1 AND (b = 2 OR c = 3)");
+      expect(expr.type).toBe('logical');
+      if (expr.type === 'logical') {
+        expect(expr.op).toBe('AND');
+        expect(expr.children[1]).toMatchObject({ type: 'logical', op: 'OR' });
+      }
+    });
+  });
+
+  describe('fallback', () => {
+    it('returns RawExpr for empty string', () => {
+      expect(parse('')).toEqual({ type: 'raw', sql: '' });
+    });
+
+    it('returns RawExpr for unparseable input', () => {
+      const expr = parse('SOME_FUNC(a, b) + 3');
+      expect(expr.type).toBe('raw');
+      if (expr.type === 'raw') {
+        expect(expr.sql).toBe('SOME_FUNC(a, b) + 3');
+      }
+    });
+  });
+
+  describe('roundtrip: toString → parse', () => {
+    const cases = [
+      "status = 'active'",
+      'height > 100',
+      "type = 'building' AND status = 'active'",
+      "a = 1 OR b = 2",
+      "name LIKE 'Main%'",
+      "type IN ('a', 'b', 'c')",
+      'pop BETWEEN 1000 AND 50000',
+      'notes IS NULL',
+      'notes IS NOT NULL',
+    ];
+
+    for (const sql of cases) {
+      it(`roundtrips: ${sql}`, () => {
+        const parsed = parse(sql);
+        const serialized = toString(parsed);
+        expect(serialized).toBe(sql);
+      });
+    }
+  });
+});

--- a/src/expressions/QueryOptions.test.ts
+++ b/src/expressions/QueryOptions.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { SortOrder, orderBy, orderByFieldsToString } from './QueryOptions';
+import type { PaginationOptions } from './QueryOptions';
+
+describe('SortOrder enum', () => {
+  it('maps to SQL keywords', () => {
+    expect(SortOrder.Ascending).toBe('ASC');
+    expect(SortOrder.Descending).toBe('DESC');
+  });
+});
+
+describe('orderBy', () => {
+  it('creates an ascending field by default', () => {
+    const entry = orderBy('name');
+    expect(entry).toEqual({ field: 'name' });
+  });
+
+  it('creates a field with explicit sort order', () => {
+    const entry = orderBy('population', SortOrder.Descending);
+    expect(entry).toEqual({ field: 'population', order: SortOrder.Descending });
+  });
+});
+
+describe('orderByFieldsToString', () => {
+  it('serializes a single field with default ascending', () => {
+    expect(orderByFieldsToString([orderBy('name')])).toBe('name ASC');
+  });
+
+  it('serializes a single field with explicit descending', () => {
+    expect(orderByFieldsToString([orderBy('population', SortOrder.Descending)])).toBe('population DESC');
+  });
+
+  it('serializes multiple fields comma-separated', () => {
+    const result = orderByFieldsToString([
+      orderBy('state'),
+      orderBy('population', SortOrder.Descending),
+      orderBy('name', SortOrder.Ascending),
+    ]);
+    expect(result).toBe('state ASC, population DESC, name ASC');
+  });
+
+  it('returns empty string for empty array', () => {
+    expect(orderByFieldsToString([])).toBe('');
+  });
+});
+
+describe('PaginationOptions', () => {
+  it('supports count only', () => {
+    const options: PaginationOptions = { count: 50 };
+    expect(options.count).toBe(50);
+    expect(options.offset).toBeUndefined();
+  });
+
+  it('supports count and offset', () => {
+    const options: PaginationOptions = { count: 25, offset: 100 };
+    expect(options.count).toBe(25);
+    expect(options.offset).toBe(100);
+  });
+});

--- a/src/expressions/QueryOptions.ts
+++ b/src/expressions/QueryOptions.ts
@@ -1,0 +1,59 @@
+/**
+ * Query options for field selection, sorting, and pagination.
+ *
+ * These map directly to Esri feature service query parameters but are
+ * general enough to apply to OGC API and other sources.
+ *
+ * @see https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-layer/
+ */
+
+// ── Sort order ──────────────────────────────────────────────────────
+
+export enum SortOrder {
+  Ascending = 'ASC',
+  Descending = 'DESC'
+}
+
+// ── Order-by clause ─────────────────────────────────────────────────
+
+export interface OrderByField {
+  field: string;
+  order?: SortOrder;
+}
+
+/**
+ * Create an order-by clause for a single field.
+ *
+ * @example
+ * ```ts
+ * orderBy('name')                        // name ASC (default)
+ * orderBy('population', SortOrder.Descending)  // population DESC
+ * ```
+ */
+export function orderBy(field: string, order?: SortOrder): OrderByField {
+  return { field, order };
+}
+
+/**
+ * Serialize an array of OrderByField entries to the Esri `orderByFields` format.
+ *
+ * @example
+ * ```ts
+ * orderByFieldsToString([orderBy('name'), orderBy('pop', SortOrder.Descending)])
+ * // → "name ASC, pop DESC"
+ * ```
+ */
+export function orderByFieldsToString(fields: OrderByField[]): string {
+  return fields
+    .map(entry => `${entry.field} ${entry.order ?? SortOrder.Ascending}`)
+    .join(', ');
+}
+
+// ── Pagination ──────────────────────────────────────────────────────
+
+export interface PaginationOptions {
+  /** Maximum number of records to return. */
+  count: number;
+  /** Number of records to skip (zero-based offset). */
+  offset?: number;
+}

--- a/src/expressions/Serialize.test.ts
+++ b/src/expressions/Serialize.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import { toString } from './Serialize';
+import { field, and, or, not, raw } from './AttributeFilter';
+
+describe('toString', () => {
+  describe('comparison', () => {
+    it('serializes string equality', () => {
+      expect(toString(field('status').eq('active'))).toBe("status = 'active'");
+    });
+
+    it('serializes numeric comparison', () => {
+      expect(toString(field('height').gt(100))).toBe('height > 100');
+    });
+
+    it('serializes null value', () => {
+      expect(toString(field('x').eq(null))).toBe('x = NULL');
+    });
+
+    it('serializes boolean as 1/0', () => {
+      expect(toString(field('active').eq(true))).toBe('active = 1');
+      expect(toString(field('active').eq(false))).toBe('active = 0');
+    });
+
+    it('serializes Date as TIMESTAMP literal', () => {
+      const d = new Date(Date.UTC(2024, 0, 15, 10, 30, 0));
+      expect(toString(field('created').gt(d))).toBe(
+        "created > TIMESTAMP '2024-01-15 10:30:00'"
+      );
+    });
+
+    it('escapes single quotes in string values', () => {
+      expect(toString(field('name').eq("O'Brien"))).toBe("name = 'O''Brien'");
+    });
+  });
+
+  describe('logical', () => {
+    it('serializes AND', () => {
+      const expr = and(field('a').eq(1), field('b').eq(2));
+      expect(toString(expr)).toBe('a = 1 AND b = 2');
+    });
+
+    it('serializes OR', () => {
+      const expr = or(field('a').eq(1), field('b').eq(2));
+      expect(toString(expr)).toBe('a = 1 OR b = 2');
+    });
+
+    it('wraps nested OR inside AND in parens', () => {
+      const expr = and(
+        field('type').eq('building'),
+        or(field('height').gt(100), field('floors').gte(10))
+      );
+      expect(toString(expr)).toBe(
+        "type = 'building' AND (height > 100 OR floors >= 10)"
+      );
+    });
+
+    it('wraps nested AND inside OR in parens', () => {
+      const expr = or(
+        and(field('a').eq(1), field('b').eq(2)),
+        field('c').eq(3)
+      );
+      expect(toString(expr)).toBe('(a = 1 AND b = 2) OR c = 3');
+    });
+
+    it('flattens same-precedence operators', () => {
+      const expr = and(field('a').eq(1), field('b').eq(2), field('c').eq(3));
+      expect(toString(expr)).toBe('a = 1 AND b = 2 AND c = 3');
+    });
+  });
+
+  describe('not', () => {
+    it('wraps expression in NOT ()', () => {
+      expect(toString(not(field('x').eq(1)))).toBe('NOT (x = 1)');
+    });
+  });
+
+  describe('like', () => {
+    it('serializes LIKE', () => {
+      expect(toString(field('name').like('Main%'))).toBe("name LIKE 'Main%'");
+    });
+
+    it('serializes NOT LIKE', () => {
+      expect(toString(field('name').notLike('%test%'))).toBe("name NOT LIKE '%test%'");
+    });
+
+    it('escapes quotes in pattern', () => {
+      expect(toString(field('name').like("O'%"))).toBe("name LIKE 'O''%'");
+    });
+  });
+
+  describe('in', () => {
+    it('serializes IN with string values', () => {
+      expect(toString(field('type').in(['a', 'b', 'c']))).toBe(
+        "type IN ('a', 'b', 'c')"
+      );
+    });
+
+    it('serializes NOT IN with numeric values', () => {
+      expect(toString(field('id').notIn([1, 2, 3]))).toBe(
+        'id NOT IN (1, 2, 3)'
+      );
+    });
+  });
+
+  describe('between', () => {
+    it('serializes BETWEEN', () => {
+      expect(toString(field('pop').between(1000, 50000))).toBe(
+        'pop BETWEEN 1000 AND 50000'
+      );
+    });
+
+    it('serializes NOT BETWEEN', () => {
+      expect(toString(field('pop').notBetween(0, 10))).toBe(
+        'pop NOT BETWEEN 0 AND 10'
+      );
+    });
+  });
+
+  describe('isNull', () => {
+    it('serializes IS NULL', () => {
+      expect(toString(field('notes').isNull())).toBe('notes IS NULL');
+    });
+
+    it('serializes IS NOT NULL', () => {
+      expect(toString(field('notes').isNotNull())).toBe('notes IS NOT NULL');
+    });
+  });
+
+  describe('raw', () => {
+    it('passes through SQL verbatim', () => {
+      expect(toString(raw("position(current_user in workers) > 0"))).toBe(
+        "position(current_user in workers) > 0"
+      );
+    });
+  });
+});

--- a/src/expressions/Serialize.ts
+++ b/src/expressions/Serialize.ts
@@ -1,0 +1,118 @@
+/**
+ * Serialize an Expression AST to an Esri SQL-92 WHERE clause string.
+ *
+ * @see https://developers.arcgis.com/rest/services-reference/enterprise/sql-reference-for-query-expressions-used-in-the-arcgis-rest-api/
+ */
+
+import { Expression, ExpressionType, ComparisonExpr, LogicalExpr, LikeExpr, InExpr, BetweenExpr, IsNullExpr, LiteralValue } from './Expression';
+
+// ── SQL keyword constants ───────────────────────────────────────────
+
+enum SqlKeyword {
+  Null = 'NULL',
+  Not = 'NOT',
+  And = 'AND',
+  Like = 'LIKE',
+  NotLike = 'NOT LIKE',
+  In = 'IN',
+  NotIn = 'NOT IN',
+  Between = 'BETWEEN',
+  NotBetween = 'NOT BETWEEN',
+  IsNull = 'IS NULL',
+  IsNotNull = 'IS NOT NULL',
+  Timestamp = 'TIMESTAMP',
+}
+
+const SINGLE_QUOTE_PATTERN = /'/g;
+
+/**
+ * Serialize a literal value to its SQL string representation.
+ */
+function literalToString(value: LiteralValue): string {
+  if (value === null) {
+    return SqlKeyword.Null;
+  }
+  if (typeof value === 'string') {
+    // Escape single quotes by doubling them (SQL-92 standard)
+    return `'${value.replace(SINGLE_QUOTE_PATTERN, "''")}'`;
+  }
+  if (typeof value === 'number') {
+    return String(value);
+  }
+  if (typeof value === 'boolean') {
+    return value ? '1' : '0';
+  }
+  if (value instanceof Date) {
+    const pad = (n: number) => String(n).padStart(2, '0');
+    const yyyy = value.getUTCFullYear();
+    const MM = pad(value.getUTCMonth() + 1);
+    const dd = pad(value.getUTCDate());
+    const HH = pad(value.getUTCHours());
+    const mm = pad(value.getUTCMinutes());
+    const ss = pad(value.getUTCSeconds());
+    return `${SqlKeyword.Timestamp} '${yyyy}-${MM}-${dd} ${HH}:${mm}:${ss}'`;
+  }
+  return String(value);
+}
+
+function comparisonToString(expr: ComparisonExpr): string {
+  return `${expr.field} ${expr.op} ${literalToString(expr.value)}`;
+}
+
+function logicalToString(expr: LogicalExpr): string {
+  const parts = expr.children.map(child => {
+    const serialized = toString(child);
+    // Wrap child logical expressions of lower precedence in parens
+    if (child.type === 'logical' && child.op !== expr.op) {
+      return `(${serialized})`;
+    }
+    return serialized;
+  });
+  return parts.join(` ${expr.op} `);
+}
+
+function likeToString(expr: LikeExpr): string {
+  const op = expr.not ? SqlKeyword.NotLike : SqlKeyword.Like;
+  return `${expr.field} ${op} '${expr.pattern.replace(SINGLE_QUOTE_PATTERN, "''")}'`;
+}
+
+function inToString(expr: InExpr): string {
+  const op = expr.not ? SqlKeyword.NotIn : SqlKeyword.In;
+  const vals = expr.values.map(literalToString).join(', ');
+  return `${expr.field} ${op} (${vals})`;
+}
+
+function betweenToString(expr: BetweenExpr): string {
+  const op = expr.not ? SqlKeyword.NotBetween : SqlKeyword.Between;
+  return `${expr.field} ${op} ${literalToString(expr.low)} ${SqlKeyword.And} ${literalToString(expr.high)}`;
+}
+
+function isNullToString(expr: IsNullExpr): string {
+  return expr.not
+    ? `${expr.field} ${SqlKeyword.IsNotNull}`
+    : `${expr.field} ${SqlKeyword.IsNull}`;
+}
+
+/**
+ * Serialize an Expression AST node to an Esri SQL-92 string.
+ */
+export function toString(expr: Expression): string {
+  switch (expr.type) {
+    case ExpressionType.Comparison:
+      return comparisonToString(expr);
+    case ExpressionType.Logical:
+      return logicalToString(expr);
+    case ExpressionType.Not:
+      return `${SqlKeyword.Not} (${toString(expr.child)})`;
+    case ExpressionType.Like:
+      return likeToString(expr);
+    case ExpressionType.In:
+      return inToString(expr);
+    case ExpressionType.Between:
+      return betweenToString(expr);
+    case ExpressionType.IsNull:
+      return isNullToString(expr);
+    case ExpressionType.Raw:
+      return expr.sql;
+  }
+}

--- a/src/expressions/Serialize.ts
+++ b/src/expressions/Serialize.ts
@@ -63,7 +63,7 @@ function logicalToString(expr: LogicalExpr): string {
   const parts = expr.children.map(child => {
     const serialized = toString(child);
     // Wrap child logical expressions of lower precedence in parens
-    if (child.type === 'logical' && child.op !== expr.op) {
+    if (child.type === ExpressionType.Logical && child.op !== expr.op) {
       return `(${serialized})`;
     }
     return serialized;
@@ -72,19 +72,19 @@ function logicalToString(expr: LogicalExpr): string {
 }
 
 function likeToString(expr: LikeExpr): string {
-  const op = expr.not ? SqlKeyword.NotLike : SqlKeyword.Like;
-  return `${expr.field} ${op} '${expr.pattern.replace(SINGLE_QUOTE_PATTERN, "''")}'`;
+  const keyword = expr.not ? SqlKeyword.NotLike : SqlKeyword.Like;
+  return `${expr.field} ${keyword} '${expr.pattern.replace(SINGLE_QUOTE_PATTERN, "''")}'`;
 }
 
 function inToString(expr: InExpr): string {
-  const op = expr.not ? SqlKeyword.NotIn : SqlKeyword.In;
-  const vals = expr.values.map(literalToString).join(', ');
-  return `${expr.field} ${op} (${vals})`;
+  const keyword = expr.not ? SqlKeyword.NotIn : SqlKeyword.In;
+  const serializedValues = expr.values.map(literalToString).join(', ');
+  return `${expr.field} ${keyword} (${serializedValues})`;
 }
 
 function betweenToString(expr: BetweenExpr): string {
-  const op = expr.not ? SqlKeyword.NotBetween : SqlKeyword.Between;
-  return `${expr.field} ${op} ${literalToString(expr.low)} ${SqlKeyword.And} ${literalToString(expr.high)}`;
+  const keyword = expr.not ? SqlKeyword.NotBetween : SqlKeyword.Between;
+  return `${expr.field} ${keyword} ${literalToString(expr.low)} ${SqlKeyword.And} ${literalToString(expr.high)}`;
 }
 
 function isNullToString(expr: IsNullExpr): string {

--- a/src/expressions/SpatialFilter.test.ts
+++ b/src/expressions/SpatialFilter.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SpatialFilter,
+  SpatialRelationship,
+  GeometryType,
+  DistanceUnit
+} from './SpatialFilter';
+import type { EsriEnvelope, EsriPoint } from './SpatialFilter';
+
+describe('SpatialFilter', () => {
+  describe('static builders', () => {
+    it('intersects() creates correct filter', () => {
+      const point: EsriPoint = { x: -122.4, y: 37.8 };
+      const filter = SpatialFilter.intersects(point, GeometryType.Point);
+      expect(filter.spatialRel).toBe(SpatialRelationship.Intersects);
+      expect(filter.geometryType).toBe(GeometryType.Point);
+      expect(filter.geometry).toBe(point);
+    });
+
+    it('contains() creates correct filter', () => {
+      const env: EsriEnvelope = { xmin: -123, ymin: 37, xmax: -122, ymax: 38 };
+      const filter = SpatialFilter.contains(env, GeometryType.Envelope);
+      expect(filter.spatialRel).toBe(SpatialRelationship.Contains);
+    });
+
+    it('within() creates correct filter', () => {
+      const env: EsriEnvelope = { xmin: -123, ymin: 37, xmax: -122, ymax: 38 };
+      const filter = SpatialFilter.within(env, GeometryType.Envelope);
+      expect(filter.spatialRel).toBe(SpatialRelationship.Within);
+    });
+
+    it('withinDistance() sets distance and units', () => {
+      const point: EsriPoint = { x: -122.4, y: 37.8 };
+      const filter = SpatialFilter.withinDistance(point, GeometryType.Point, 1000, DistanceUnit.Meter);
+      expect(filter.distance).toBe(1000);
+      expect(filter.units).toBe(DistanceUnit.Meter);
+      expect(filter.spatialRel).toBe(SpatialRelationship.Intersects);
+    });
+
+    it('withinDistance() defaults to meters', () => {
+      const point: EsriPoint = { x: 0, y: 0 };
+      const filter = SpatialFilter.withinDistance(point, GeometryType.Point, 500);
+      expect(filter.units).toBe(DistanceUnit.Meter);
+    });
+
+    it('fromEnvelope() creates envelope intersection filter', () => {
+      const filter = SpatialFilter.fromEnvelope(-123, 37, -122, 38, 4326);
+      expect(filter.geometryType).toBe(GeometryType.Envelope);
+      expect(filter.spatialRel).toBe(SpatialRelationship.Intersects);
+      const geom = filter.geometry as EsriEnvelope;
+      expect(geom.xmin).toBe(-123);
+      expect(geom.ymin).toBe(37);
+      expect(geom.xmax).toBe(-122);
+      expect(geom.ymax).toBe(38);
+      expect(geom.spatialReference).toEqual({ wkid: 4326 });
+    });
+
+    it('fromEnvelope() without wkid omits spatialReference', () => {
+      const filter = SpatialFilter.fromEnvelope(0, 0, 1, 1);
+      const geom = filter.geometry as EsriEnvelope;
+      expect(geom.spatialReference).toBeUndefined();
+    });
+  });
+
+  describe('toQueryParams()', () => {
+    it('includes required parameters', () => {
+      const point: EsriPoint = { x: -122.4, y: 37.8 };
+      const filter = SpatialFilter.intersects(point, GeometryType.Point);
+      const params = filter.toQueryParams();
+
+      expect(params['geometryType']).toBe('esriGeometryPoint');
+      expect(params['spatialRel']).toBe('esriSpatialRelIntersects');
+      expect(params['geometry']).toBe(JSON.stringify(point));
+    });
+
+    it('serializes string geometry as-is', () => {
+      const filter = SpatialFilter.intersects('-122.4,37.8', GeometryType.Point);
+      expect(filter.toQueryParams()['geometry']).toBe('-122.4,37.8');
+    });
+
+    it('includes distance and units when set', () => {
+      const point: EsriPoint = { x: 0, y: 0 };
+      const filter = SpatialFilter.withinDistance(point, GeometryType.Point, 500, DistanceUnit.Kilometer);
+      const params = filter.toQueryParams();
+
+      expect(params['distance']).toBe('500');
+      expect(params['units']).toBe('esriSRUnit_Kilometer');
+    });
+
+    it('includes inSR when set as number', () => {
+      const filter = new SpatialFilter({
+        geometry: { x: 0, y: 0 },
+        geometryType: GeometryType.Point,
+        spatialRel: SpatialRelationship.Intersects,
+        inSR: 4326
+      });
+      expect(filter.toQueryParams()['inSR']).toBe('4326');
+    });
+
+    it('includes inSR when set as object', () => {
+      const filter = new SpatialFilter({
+        geometry: { x: 0, y: 0 },
+        geometryType: GeometryType.Point,
+        spatialRel: SpatialRelationship.Intersects,
+        inSR: { wkid: 4326 }
+      });
+      expect(filter.toQueryParams()['inSR']).toBe(JSON.stringify({ wkid: 4326 }));
+    });
+  });
+});
+
+describe('enum values', () => {
+  it('SpatialRelationship has Esri enum values', () => {
+    expect(SpatialRelationship.Intersects).toBe('esriSpatialRelIntersects');
+    expect(SpatialRelationship.Within).toBe('esriSpatialRelWithin');
+    expect(SpatialRelationship.Contains).toBe('esriSpatialRelContains');
+  });
+
+  it('GeometryType has Esri enum values', () => {
+    expect(GeometryType.Point).toBe('esriGeometryPoint');
+    expect(GeometryType.Polygon).toBe('esriGeometryPolygon');
+    expect(GeometryType.Envelope).toBe('esriGeometryEnvelope');
+  });
+
+  it('DistanceUnit has Esri enum values', () => {
+    expect(DistanceUnit.Meter).toBe('esriSRUnit_Meter');
+    expect(DistanceUnit.Kilometer).toBe('esriSRUnit_Kilometer');
+    expect(DistanceUnit.StatuteMile).toBe('esriSRUnit_StatuteMile');
+  });
+});

--- a/src/expressions/SpatialFilter.ts
+++ b/src/expressions/SpatialFilter.ts
@@ -1,0 +1,192 @@
+/**
+ * Typed spatial filter configuration for Esri feature service queries.
+ *
+ * Spatial filters constrain query results to features that have a specific
+ * spatial relationship with an input geometry (e.g., intersects, within,
+ * contains). Optionally includes a distance buffer.
+ *
+ * @see https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-layer/
+ * @see https://developers.arcgis.com/rest/services-reference/enterprise/geometry-objects/
+ */
+
+// ── Esri spatial relationship values ────────────────────────────────
+
+export enum SpatialRelationship {
+  Intersects = 'esriSpatialRelIntersects',
+  Contains = 'esriSpatialRelContains',
+  Crosses = 'esriSpatialRelCrosses',
+  EnvelopeIntersects = 'esriSpatialRelEnvelopeIntersects',
+  IndexIntersects = 'esriSpatialRelIndexIntersects',
+  Overlaps = 'esriSpatialRelOverlaps',
+  Touches = 'esriSpatialRelTouches',
+  Within = 'esriSpatialRelWithin'
+}
+
+// ── Esri geometry type values ───────────────────────────────────────
+
+export enum GeometryType {
+  Point = 'esriGeometryPoint',
+  Multipoint = 'esriGeometryMultipoint',
+  Polyline = 'esriGeometryPolyline',
+  Polygon = 'esriGeometryPolygon',
+  Envelope = 'esriGeometryEnvelope'
+}
+
+// ── Distance unit values ────────────────────────────────────────────
+
+export enum DistanceUnit {
+  Meter = 'esriSRUnit_Meter',
+  Foot = 'esriSRUnit_Foot',
+  Kilometer = 'esriSRUnit_Kilometer',
+  StatuteMile = 'esriSRUnit_StatuteMile',
+  NauticalMile = 'esriSRUnit_NauticalMile'
+}
+
+// ── Geometry input types ────────────────────────────────────────────
+
+/**
+ * Esri envelope geometry (bounding box).
+ */
+export interface EsriEnvelope {
+  xmin: number;
+  ymin: number;
+  xmax: number;
+  ymax: number;
+  spatialReference?: { wkid: number };
+}
+
+/**
+ * Esri point geometry.
+ */
+export interface EsriPoint {
+  x: number;
+  y: number;
+  spatialReference?: { wkid: number };
+}
+
+/**
+ * Any Esri geometry JSON object, or a simple comma-delimited string.
+ *
+ * `EsriEnvelope` and `EsriPoint` cover the most common cases. For more complex
+ * geometry types (Polyline with `paths`, Polygon with `rings`, Multipoint with
+ * `points`), `Record<string, unknown>` serves as an escape hatch — these
+ * structures vary by geometry type and are serialized to JSON for the Esri
+ * query API.
+ *
+ * @see https://developers.arcgis.com/rest/services-reference/enterprise/geometry-objects/
+ */
+export type GeometryInput = EsriEnvelope | EsriPoint | Record<string, unknown> | string;
+
+// ── Spatial filter interface ────────────────────────────────────────
+
+export interface ISpatialFilter {
+  geometry: GeometryInput;
+  geometryType: GeometryType;
+  spatialRel: SpatialRelationship;
+  inSR?: number | { wkid: number };
+  distance?: number;
+  units?: DistanceUnit;
+}
+
+/**
+ * Typed spatial filter that serializes to Esri query parameters.
+ */
+export class SpatialFilter implements ISpatialFilter {
+  geometry: GeometryInput;
+  geometryType: GeometryType;
+  spatialRel: SpatialRelationship;
+  inSR?: number | { wkid: number };
+  distance?: number;
+  units?: DistanceUnit;
+
+  constructor(config: ISpatialFilter) {
+    this.geometry = config.geometry;
+    this.geometryType = config.geometryType;
+    this.spatialRel = config.spatialRel;
+    this.inSR = config.inSR;
+    this.distance = config.distance;
+    this.units = config.units;
+  }
+
+  /**
+   * Create a spatial filter that finds features intersecting the given geometry.
+   */
+  static intersects(geometry: GeometryInput, geometryType: GeometryType): SpatialFilter {
+    return new SpatialFilter({ geometry, geometryType, spatialRel: SpatialRelationship.Intersects });
+  }
+
+  /**
+   * Create a spatial filter that finds features contained by the given geometry.
+   */
+  static contains(geometry: GeometryInput, geometryType: GeometryType): SpatialFilter {
+    return new SpatialFilter({ geometry, geometryType, spatialRel: SpatialRelationship.Contains });
+  }
+
+  /**
+   * Create a spatial filter that finds features within the given geometry.
+   */
+  static within(geometry: GeometryInput, geometryType: GeometryType): SpatialFilter {
+    return new SpatialFilter({ geometry, geometryType, spatialRel: SpatialRelationship.Within });
+  }
+
+  /**
+   * Create a spatial filter that finds features within a distance of the given geometry.
+   */
+  static withinDistance(
+    geometry: GeometryInput,
+    geometryType: GeometryType,
+    distance: number,
+    units: DistanceUnit = DistanceUnit.Meter
+  ): SpatialFilter {
+    return new SpatialFilter({
+      geometry,
+      geometryType,
+      spatialRel: SpatialRelationship.Intersects,
+      distance,
+      units
+    });
+  }
+
+  /**
+   * Create a spatial filter using an envelope (bounding box).
+   */
+  static fromEnvelope(xmin: number, ymin: number, xmax: number, ymax: number, wkid?: number): SpatialFilter {
+    const envelope: EsriEnvelope = { xmin, ymin, xmax, ymax };
+    if (wkid) {
+      envelope.spatialReference = { wkid };
+    }
+    return SpatialFilter.intersects(envelope, GeometryType.Envelope);
+  }
+
+  /**
+   * Convert to Esri query parameters.
+   */
+  toQueryParams(): Record<string, string> {
+    const params: Record<string, string> = {};
+
+    params['geometryType'] = this.geometryType;
+    params['spatialRel'] = this.spatialRel;
+
+    if (typeof this.geometry === 'string') {
+      params['geometry'] = this.geometry;
+    } else {
+      params['geometry'] = JSON.stringify(this.geometry);
+    }
+
+    if (this.inSR !== undefined) {
+      params['inSR'] = typeof this.inSR === 'number'
+        ? String(this.inSR)
+        : JSON.stringify(this.inSR);
+    }
+
+    if (this.distance !== undefined) {
+      params['distance'] = String(this.distance);
+    }
+
+    if (this.units) {
+      params['units'] = this.units;
+    }
+
+    return params;
+  }
+}

--- a/src/expressions/TemporalFilter.test.ts
+++ b/src/expressions/TemporalFilter.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TimeInstant,
+  TimeExtent,
+  IntervalUnit,
+  CompoundIntervalUnit,
+  interval,
+  intervalToString
+} from './TemporalFilter';
+
+describe('TimeInstant', () => {
+  it('fromEpochMs() stores epoch ms', () => {
+    const ti = TimeInstant.fromEpochMs(1700000000000);
+    expect(ti.epochMs).toBe(1700000000000);
+  });
+
+  it('fromDate() converts Date to epoch ms', () => {
+    const d = new Date(Date.UTC(2024, 5, 15, 12, 0, 0));
+    const ti = TimeInstant.fromDate(d);
+    expect(ti.epochMs).toBe(d.getTime());
+  });
+
+  it('toQueryParam() returns epoch ms string', () => {
+    const ti = TimeInstant.fromEpochMs(1700000000000);
+    expect(ti.toQueryParam()).toBe('1700000000000');
+  });
+
+  it('toTimestampLiteral() formats correctly', () => {
+    const d = new Date(Date.UTC(2024, 0, 15, 10, 30, 0));
+    const ti = TimeInstant.fromDate(d);
+    expect(ti.toTimestampLiteral()).toBe("TIMESTAMP '2024-01-15 10:30:00'");
+  });
+
+  it('toTimestampLiteral() zero-pads single-digit components', () => {
+    const d = new Date(Date.UTC(2024, 0, 5, 3, 7, 9));
+    const ti = TimeInstant.fromDate(d);
+    expect(ti.toTimestampLiteral()).toBe("TIMESTAMP '2024-01-05 03:07:09'");
+  });
+});
+
+describe('TimeExtent', () => {
+  it('create() stores start and end instants', () => {
+    const start = TimeInstant.fromEpochMs(1000);
+    const end = TimeInstant.fromEpochMs(2000);
+    const extent = TimeExtent.create(start, end);
+    expect(extent.start).toBe(start);
+    expect(extent.end).toBe(end);
+  });
+
+  it('fromEpochMs() converts ms values', () => {
+    const extent = TimeExtent.fromEpochMs(1000, 2000);
+    expect(extent.start!.epochMs).toBe(1000);
+    expect(extent.end!.epochMs).toBe(2000);
+  });
+
+  it('fromEpochMs() supports null for open-ended ranges', () => {
+    const fromStart = TimeExtent.fromEpochMs(null, 2000);
+    expect(fromStart.start).toBeNull();
+    expect(fromStart.end!.epochMs).toBe(2000);
+
+    const toEnd = TimeExtent.fromEpochMs(1000, null);
+    expect(toEnd.start!.epochMs).toBe(1000);
+    expect(toEnd.end).toBeNull();
+  });
+
+  it('fromDates() converts Date objects', () => {
+    const d1 = new Date(Date.UTC(2024, 0, 1));
+    const d2 = new Date(Date.UTC(2024, 11, 31));
+    const extent = TimeExtent.fromDates(d1, d2);
+    expect(extent.start!.epochMs).toBe(d1.getTime());
+    expect(extent.end!.epochMs).toBe(d2.getTime());
+  });
+
+  it('fromDates() supports null for open-ended ranges', () => {
+    const extent = TimeExtent.fromDates(null, new Date(Date.UTC(2024, 0, 1)));
+    expect(extent.start).toBeNull();
+  });
+
+  it('toQueryParam() returns comma-separated epoch ms', () => {
+    const extent = TimeExtent.fromEpochMs(1000, 2000);
+    expect(extent.toQueryParam()).toBe('1000,2000');
+  });
+
+  it('toQueryParam() uses null for open ends', () => {
+    expect(TimeExtent.fromEpochMs(null, 2000).toQueryParam()).toBe('null,2000');
+    expect(TimeExtent.fromEpochMs(1000, null).toQueryParam()).toBe('1000,null');
+  });
+});
+
+describe('interval()', () => {
+  it('creates an IntervalExpression with simple unit', () => {
+    const expr = interval('3', IntervalUnit.Day);
+    expect(expr).toEqual({ value: '3', unit: 'DAY' });
+  });
+
+  it('creates an IntervalExpression with compound unit', () => {
+    const expr = interval('3 05:32:28', CompoundIntervalUnit.DayToSecond);
+    expect(expr).toEqual({ value: '3 05:32:28', unit: 'DAY TO SECOND' });
+  });
+});
+
+describe('intervalToString()', () => {
+  it('produces correct SQL fragment for simple unit', () => {
+    expect(intervalToString(interval('7', IntervalUnit.Day))).toBe("INTERVAL '7' DAY");
+  });
+
+  it('produces correct SQL fragment for compound unit', () => {
+    expect(intervalToString(interval('1 12:00:00', CompoundIntervalUnit.DayToSecond)))
+      .toBe("INTERVAL '1 12:00:00' DAY TO SECOND");
+  });
+
+  it('serializes all IntervalUnit values', () => {
+    expect(intervalToString(interval('30', IntervalUnit.Minute))).toBe("INTERVAL '30' MINUTE");
+    expect(intervalToString(interval('2', IntervalUnit.Hour))).toBe("INTERVAL '2' HOUR");
+    expect(intervalToString(interval('45', IntervalUnit.Second))).toBe("INTERVAL '45' SECOND");
+  });
+});

--- a/src/expressions/TemporalFilter.ts
+++ b/src/expressions/TemporalFilter.ts
@@ -1,0 +1,157 @@
+/**
+ * Typed temporal filter for Esri feature service queries.
+ *
+ * Supports time instants, time extents (ranges), and SQL INTERVAL expressions
+ * for relative date/time queries using CURRENT_TIMESTAMP.
+ *
+ * @see https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-layer/
+ * @see https://www.esri.com/arcgis-blog/products/api-rest/data-management/querying-feature-services-date-time-queries/
+ */
+
+// ── Interval units for CURRENT_TIMESTAMP +/- INTERVAL syntax ────────
+
+export enum IntervalUnit {
+  Day = 'DAY',
+  Hour = 'HOUR',
+  Minute = 'MINUTE',
+  Second = 'SECOND'
+}
+
+// ── Compound interval units ─────────────────────────────────────────
+
+export enum CompoundIntervalUnit {
+  DayToHour = 'DAY TO HOUR',
+  DayToMinute = 'DAY TO MINUTE',
+  DayToSecond = 'DAY TO SECOND',
+  HourToMinute = 'HOUR TO MINUTE',
+  HourToSecond = 'HOUR TO SECOND',
+  MinuteToSecond = 'MINUTE TO SECOND'
+}
+
+// ── Time instant ────────────────────────────────────────────────────
+
+/**
+ * A point in time, stored as epoch milliseconds.
+ */
+export class TimeInstant {
+  readonly epochMs: number;
+
+  private constructor(epochMs: number) {
+    this.epochMs = epochMs;
+  }
+
+  static fromEpochMs(ms: number): TimeInstant {
+    return new TimeInstant(ms);
+  }
+
+  static fromDate(date: Date): TimeInstant {
+    return new TimeInstant(date.getTime());
+  }
+
+  /**
+   * Serialize for the Esri `time=` query parameter.
+   */
+  toQueryParam(): string {
+    return String(this.epochMs);
+  }
+
+  /**
+   * Format as an Esri SQL TIMESTAMP literal for use in WHERE clauses.
+   * Output: `TIMESTAMP 'yyyy-MM-dd HH:mm:ss'`
+   */
+  toTimestampLiteral(): string {
+    const d = new Date(this.epochMs);
+    const pad = (n: number, len = 2) => String(n).padStart(len, '0');
+    const yyyy = d.getUTCFullYear();
+    const MM = pad(d.getUTCMonth() + 1);
+    const dd = pad(d.getUTCDate());
+    const HH = pad(d.getUTCHours());
+    const mm = pad(d.getUTCMinutes());
+    const ss = pad(d.getUTCSeconds());
+    return `TIMESTAMP '${yyyy}-${MM}-${dd} ${HH}:${mm}:${ss}'`;
+  }
+}
+
+// ── Time extent (range) ─────────────────────────────────────────────
+
+/**
+ * A time range with optional open ends.
+ * `null` for start means "from the beginning of time."
+ * `null` for end means "to the present."
+ */
+export class TimeExtent {
+  readonly start: TimeInstant | null;
+  readonly end: TimeInstant | null;
+
+  private constructor(start: TimeInstant | null, end: TimeInstant | null) {
+    this.start = start;
+    this.end = end;
+  }
+
+  static create(start: TimeInstant | null, end: TimeInstant | null): TimeExtent {
+    return new TimeExtent(start, end);
+  }
+
+  static fromEpochMs(startMs: number | null, endMs: number | null): TimeExtent {
+    return new TimeExtent(
+      startMs !== null ? TimeInstant.fromEpochMs(startMs) : null,
+      endMs !== null ? TimeInstant.fromEpochMs(endMs) : null
+    );
+  }
+
+  static fromDates(start: Date | null, end: Date | null): TimeExtent {
+    return new TimeExtent(
+      start ? TimeInstant.fromDate(start) : null,
+      end ? TimeInstant.fromDate(end) : null
+    );
+  }
+
+  /**
+   * Serialize for the Esri `time=` query parameter.
+   * Format: `<startTime>,<endTime>` — null values become `null`.
+   */
+  toQueryParam(): string {
+    const queryStart = this.start ? this.start.toQueryParam() : 'null';
+    const queryEnd = this.end ? this.end.toQueryParam() : 'null';
+    return `${queryStart},${queryEnd}`;
+  }
+}
+
+// ── Interval expression for WHERE clause relative queries ───────────
+
+/**
+ * Represents a SQL INTERVAL expression for relative date queries.
+ *
+ * Usage in WHERE clauses:
+ * ```sql
+ * DateField >= CURRENT_TIMESTAMP - INTERVAL '3' DAY
+ * DateField >= CURRENT_TIMESTAMP - INTERVAL '3 05:32:28' DAY TO SECOND
+ * ```
+ */
+export interface IntervalExpression {
+  value: string;
+  unit: IntervalUnit | CompoundIntervalUnit;
+}
+
+/**
+ * Create an INTERVAL expression for use in WHERE clause date/time queries.
+ *
+ * @example
+ * ```ts
+ * interval('3', IntervalUnit.Day)
+ * // produces: INTERVAL '3' DAY
+ *
+ * interval('3 05:32:28', CompoundIntervalUnit.DayToSecond)
+ * // produces: INTERVAL '3 05:32:28' DAY TO SECOND
+ * ```
+ */
+export function interval(value: string, unit: IntervalUnit | CompoundIntervalUnit): IntervalExpression {
+  return { value, unit };
+}
+
+/**
+ * Serialize an IntervalExpression to an Esri SQL fragment.
+ */
+export function intervalToString(expr: IntervalExpression): string {
+  return `INTERVAL '${expr.value}' ${expr.unit}`;
+}

--- a/src/expressions/index.ts
+++ b/src/expressions/index.ts
@@ -22,7 +22,7 @@ export {
   DistanceUnit,
   SpatialFilter
 } from './SpatialFilter';
-export type { EsriEnvelope, EsriPoint, GeometryInput } from './SpatialFilter';
+export type { ISpatialFilter, EsriEnvelope, EsriPoint, GeometryInput } from './SpatialFilter';
 
 export {
   TimeInstant,

--- a/src/expressions/index.ts
+++ b/src/expressions/index.ts
@@ -1,0 +1,38 @@
+// Barrel exports for the expressions module
+
+export type {
+  Expression,
+  ComparisonExpr,
+  LogicalExpr,
+  NotExpr,
+  LikeExpr,
+  InExpr,
+  BetweenExpr,
+  IsNullExpr,
+  RawExpr,
+  LiteralValue
+} from './Expression';
+export { ComparisonOp, LogicalOp, ExpressionType } from './Expression';
+
+export { FieldRef, field, and, or, not, raw } from './AttributeFilter';
+
+export {
+  SpatialRelationship,
+  GeometryType,
+  DistanceUnit,
+  SpatialFilter
+} from './SpatialFilter';
+export type { EsriEnvelope, EsriPoint, GeometryInput } from './SpatialFilter';
+
+export {
+  TimeInstant,
+  TimeExtent,
+  IntervalUnit,
+  CompoundIntervalUnit,
+  interval,
+  intervalToString
+} from './TemporalFilter';
+export type { IntervalExpression } from './TemporalFilter';
+
+export { toString } from './Serialize';
+export { parse } from './parsing';

--- a/src/expressions/index.ts
+++ b/src/expressions/index.ts
@@ -36,3 +36,10 @@ export type { IntervalExpression } from './TemporalFilter';
 
 export { toString } from './Serialize';
 export { parse } from './parsing';
+
+export {
+  SortOrder,
+  orderBy,
+  orderByFieldsToString
+} from './QueryOptions';
+export type { OrderByField, PaginationOptions } from './QueryOptions';

--- a/src/expressions/parsing/Constants.ts
+++ b/src/expressions/parsing/Constants.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared constants for SQL tokenization and parsing.
+ */
+
+// ── Token types ─────────────────────────────────────────────────────
+
+export enum TokenType {
+  String = 'STRING',
+  Number = 'NUMBER',
+  Null = 'NULL',
+  Timestamp = 'TIMESTAMP',
+  Ident = 'IDENT',
+  LeftParen = 'LPAREN',
+  RightParen = 'RPAREN',
+  Comma = 'COMMA',
+  Operator = 'OP',
+  And = 'AND',
+  Or = 'OR',
+  Not = 'NOT',
+  Like = 'LIKE',
+  In = 'IN',
+  Between = 'BETWEEN',
+  Is = 'IS',
+  Eof = 'EOF',
+}
+
+export interface Token {
+  type: TokenType;
+  value: string;
+  pos: number;
+}
+
+// ── SQL keyword mappings ────────────────────────────────────────────
+
+/** SQL keywords mapped to their token types. */
+export const KEYWORD_TOKENS: ReadonlyMap<string, TokenType> = new Map([
+  ['AND', TokenType.And],
+  ['OR', TokenType.Or],
+  ['NOT', TokenType.Not],
+  ['LIKE', TokenType.Like],
+  ['IN', TokenType.In],
+  ['BETWEEN', TokenType.Between],
+  ['IS', TokenType.Is],
+  ['NULL', TokenType.Null],
+]);
+
+export const TIMESTAMP_KEYWORD = 'TIMESTAMP';
+
+/** Two-character operators mapped to their canonical SQL form. */
+export const TWO_CHAR_OPERATORS: ReadonlyMap<string, string> = new Map([
+  ['<>', '<>'],
+  ['<=', '<='],
+  ['>=', '>='],
+  ['!=', '<>'],
+]);
+
+/** Single-character comparison operators. */
+export const SINGLE_CHAR_OPERATORS = new Set(['=', '<', '>']);
+
+/** Single-character punctuation mapped to token types. */
+export const PUNCTUATION_TOKENS: ReadonlyMap<string, TokenType> = new Map([
+  ['(', TokenType.LeftParen],
+  [')', TokenType.RightParen],
+  [',', TokenType.Comma],
+]);
+
+// ── Character-class regex patterns ──────────────────────────────────
+
+/** Matches a single whitespace character. */
+export const WHITESPACE_PATTERN = /\s/;
+
+/** Matches a digit character (0-9). */
+export const DIGIT_PATTERN = /[0-9]/;
+
+/** Matches a digit or decimal-point character. */
+export const DIGIT_OR_DOT_PATTERN = /[0-9.]/;
+
+/** Matches a valid first character of an SQL identifier (letter or underscore). */
+export const WORD_START_PATTERN = /[a-zA-Z_]/;
+
+/** Matches subsequent characters of an SQL identifier (letter, digit, or underscore). */
+export const WORD_CHAR_PATTERN = /[a-zA-Z0-9_]/;

--- a/src/expressions/parsing/Parser.ts
+++ b/src/expressions/parsing/Parser.ts
@@ -53,9 +53,9 @@ class Parser {
   }
 
   private expect(type: TokenType): Token {
-    const tok = this.peek();
-    if (tok.type !== type) {
-      throw new Error(`Expected ${type} but got ${tok.type} ('${tok.value}') at position ${tok.pos}`);
+    const token = this.peek();
+    if (token.type !== type) {
+      throw new Error(`Expected ${type} but got ${token.type} ('${token.value}') at position ${token.pos}`);
     }
     return this.advance();
   }
@@ -68,24 +68,24 @@ class Parser {
   }
 
   private parseLiteral(): LiteralValue {
-    const tok = this.peek();
-    if (tok.type === TokenType.String) {
+    const token = this.peek();
+    if (token.type === TokenType.String) {
       this.advance();
-      return tok.value;
+      return token.value;
     }
-    if (tok.type === TokenType.Number) {
+    if (token.type === TokenType.Number) {
       this.advance();
-      return tok.value.includes('.') ? parseFloat(tok.value) : parseInt(tok.value, 10);
+      return token.value.includes('.') ? parseFloat(token.value) : parseInt(token.value, 10);
     }
-    if (tok.type === TokenType.Null) {
+    if (token.type === TokenType.Null) {
       this.advance();
       return null;
     }
-    if (tok.type === TokenType.Timestamp) {
+    if (token.type === TokenType.Timestamp) {
       this.advance();
-      return new Date(tok.value + UTC_SUFFIX);
+      return new Date(token.value + UTC_SUFFIX);
     }
-    throw new Error(`Expected literal value at position ${tok.pos}`);
+    throw new Error(`Expected literal value at position ${token.pos}`);
   }
 
   isAtEnd(): boolean {

--- a/src/expressions/parsing/Parser.ts
+++ b/src/expressions/parsing/Parser.ts
@@ -1,0 +1,281 @@
+/**
+ * Recursive descent parser: SQL-92 WHERE clause string → Expression AST.
+ *
+ * Supports the subset used by Esri feature services:
+ * - Comparison operators: =, <>, <, >, <=, >=
+ * - Logical operators: AND, OR, NOT
+ * - LIKE / NOT LIKE with wildcards
+ * - IN / NOT IN (value lists)
+ * - BETWEEN / NOT BETWEEN
+ * - IS NULL / IS NOT NULL
+ * - Parenthesized groups
+ * - String literals (single-quoted), numeric literals, NULL
+ * - TIMESTAMP literals
+ *
+ * Falls back to RawExpr for unrecognized syntax instead of throwing.
+ *
+ * @see https://developers.arcgis.com/rest/services-reference/enterprise/sql-reference-for-query-expressions-used-in-the-arcgis-rest-api/
+ */
+
+import {
+  Expression,
+  ExpressionType,
+  ComparisonOp,
+  LogicalOp,
+  LiteralValue,
+  RawExpr
+} from '../Expression';
+
+import { Token, TokenType } from './Constants';
+import { Tokenizer } from './Tokenizer';
+
+// ── UTC timezone suffix for TIMESTAMP parsing ───────────────────────
+
+const UTC_SUFFIX = 'Z';
+
+// ── Parser ──────────────────────────────────────────────────────────
+
+class Parser {
+  private readonly tokens: Token[];
+  private pos: number;
+
+  constructor(tokens: Token[]) {
+    this.tokens = tokens;
+    this.pos = 0;
+  }
+
+  private peek(): Token {
+    return this.tokens[this.pos];
+  }
+
+  private advance(): Token {
+    return this.tokens[this.pos++];
+  }
+
+  private expect(type: TokenType): Token {
+    const tok = this.peek();
+    if (tok.type !== type) {
+      throw new Error(`Expected ${type} but got ${tok.type} ('${tok.value}') at position ${tok.pos}`);
+    }
+    return this.advance();
+  }
+
+  private match(type: TokenType): Token | null {
+    if (this.peek().type === type) {
+      return this.advance();
+    }
+    return null;
+  }
+
+  private parseLiteral(): LiteralValue {
+    const tok = this.peek();
+    if (tok.type === TokenType.String) {
+      this.advance();
+      return tok.value;
+    }
+    if (tok.type === TokenType.Number) {
+      this.advance();
+      return tok.value.includes('.') ? parseFloat(tok.value) : parseInt(tok.value, 10);
+    }
+    if (tok.type === TokenType.Null) {
+      this.advance();
+      return null;
+    }
+    if (tok.type === TokenType.Timestamp) {
+      this.advance();
+      return new Date(tok.value + UTC_SUFFIX);
+    }
+    throw new Error(`Expected literal value at position ${tok.pos}`);
+  }
+
+  isAtEnd(): boolean {
+    return this.peek().type === TokenType.Eof;
+  }
+
+  /**
+   * Parse OR expressions (lowest precedence).
+   */
+  parseOr(): Expression {
+    let left = this.parseAnd();
+
+    while (this.peek().type === TokenType.Or) {
+      this.advance();
+      const right = this.parseAnd();
+      if (left.type === ExpressionType.Logical && left.op === LogicalOp.Or) {
+        left.children.push(right);
+      } else {
+        left = { type: ExpressionType.Logical, op: LogicalOp.Or, children: [left, right] };
+      }
+    }
+
+    return left;
+  }
+
+  /**
+   * Parse AND expressions.
+   */
+  private parseAnd(): Expression {
+    let left = this.parseNot();
+
+    while (this.peek().type === TokenType.And) {
+      this.advance();
+      const right = this.parseNot();
+      if (left.type === ExpressionType.Logical && left.op === LogicalOp.And) {
+        left.children.push(right);
+      } else {
+        left = { type: ExpressionType.Logical, op: LogicalOp.And, children: [left, right] };
+      }
+    }
+
+    return left;
+  }
+
+  /**
+   * Parse NOT prefix.
+   */
+  private parseNot(): Expression {
+    if (this.peek().type === TokenType.Not) {
+      this.advance();
+      const child = this.parseNot();
+      return { type: ExpressionType.Not, child };
+    }
+    return this.parsePrimary();
+  }
+
+  /**
+   * Parse primary expressions: comparisons, LIKE, IN, BETWEEN, IS NULL, parenthesized groups.
+   */
+  private parsePrimary(): Expression {
+    // Parenthesized group
+    if (this.peek().type === TokenType.LeftParen) {
+      this.advance();
+      const expr = this.parseOr();
+      this.expect(TokenType.RightParen);
+      return expr;
+    }
+
+    // Must be an identifier (field name)
+    if (this.peek().type !== TokenType.Ident) {
+      throw new Error(`Unexpected token '${this.peek().value}' at position ${this.peek().pos}`);
+    }
+
+    const fieldToken = this.advance();
+    const fieldName = fieldToken.value;
+    const next = this.peek();
+
+    // IS [NOT] NULL
+    if (next.type === TokenType.Is) {
+      this.advance();
+      const notToken = this.match(TokenType.Not);
+      this.expect(TokenType.Null);
+      return { type: ExpressionType.IsNull, field: fieldName, not: Boolean(notToken) };
+    }
+
+    // [NOT] LIKE
+    if (next.type === TokenType.Like) {
+      this.advance();
+      const pattern = this.expect(TokenType.String).value;
+      return { type: ExpressionType.Like, field: fieldName, pattern };
+    }
+    if (next.type === TokenType.Not) {
+      const savedPos = this.pos;
+      this.advance();
+      if (this.peek().type === TokenType.Like) {
+        this.advance();
+        const pattern = this.expect(TokenType.String).value;
+        return { type: ExpressionType.Like, field: fieldName, pattern, not: true };
+      }
+      if (this.peek().type === TokenType.In) {
+        this.advance();
+        return this.parseInList(fieldName, true);
+      }
+      if (this.peek().type === TokenType.Between) {
+        this.advance();
+        return this.parseBetweenValues(fieldName, true);
+      }
+      // Backtrack — NOT was not part of a LIKE/IN/BETWEEN
+      this.pos = savedPos;
+    }
+
+    // IN (value list)
+    if (next.type === TokenType.In) {
+      this.advance();
+      return this.parseInList(fieldName, false);
+    }
+
+    // BETWEEN
+    if (next.type === TokenType.Between) {
+      this.advance();
+      return this.parseBetweenValues(fieldName, false);
+    }
+
+    // Comparison operator
+    if (next.type === TokenType.Operator) {
+      this.advance();
+      const value = this.parseLiteral();
+      return {
+        type: ExpressionType.Comparison,
+        field: fieldName,
+        op: next.value as ComparisonOp,
+        value
+      };
+    }
+
+    throw new Error(`Unexpected token '${next.value}' after field '${fieldName}' at position ${next.pos}`);
+  }
+
+  private parseInList(fieldName: string, not: boolean): Expression {
+    this.expect(TokenType.LeftParen);
+    const values: LiteralValue[] = [];
+    values.push(this.parseLiteral());
+    while (this.match(TokenType.Comma)) {
+      values.push(this.parseLiteral());
+    }
+    this.expect(TokenType.RightParen);
+    return { type: ExpressionType.In, field: fieldName, values, not: not || undefined };
+  }
+
+  private parseBetweenValues(fieldName: string, not: boolean): Expression {
+    const low = this.parseLiteral();
+    this.expect(TokenType.And);
+    const high = this.parseLiteral();
+    return { type: ExpressionType.Between, field: fieldName, low, high, not: not || undefined };
+  }
+}
+
+/**
+ * Parse an Esri SQL-92 WHERE clause string into an Expression AST.
+ *
+ * Falls back to a RawExpr for input that cannot be parsed, rather than throwing.
+ *
+ * @example
+ * ```ts
+ * parse("type = 'building' AND status = 'active'")
+ * // → LogicalExpr { op: 'AND', children: [ComparisonExpr, ComparisonExpr] }
+ *
+ * parse("some_unsupported_syntax()")
+ * // → RawExpr { sql: "some_unsupported_syntax()" }
+ * ```
+ */
+export function parse(sql: string): Expression {
+  const trimmed = sql.trim();
+  if (!trimmed) {
+    return { type: ExpressionType.Raw, sql: '' } satisfies RawExpr;
+  }
+
+  try {
+    const tokens = new Tokenizer(trimmed).tokenize();
+    const parser = new Parser(tokens);
+    const expr = parser.parseOr();
+
+    // Ensure we consumed all tokens
+    if (!parser.isAtEnd()) {
+      return { type: ExpressionType.Raw, sql: trimmed };
+    }
+
+    return expr;
+  } catch {
+    // Fall back to raw expression on any parse error
+    return { type: ExpressionType.Raw, sql: trimmed };
+  }
+}

--- a/src/expressions/parsing/Tokenizer.ts
+++ b/src/expressions/parsing/Tokenizer.ts
@@ -1,0 +1,183 @@
+/**
+ * SQL-92 tokenizer for Esri WHERE clause expressions.
+ */
+
+import {
+  Token,
+  TokenType,
+  KEYWORD_TOKENS,
+  TIMESTAMP_KEYWORD,
+  TWO_CHAR_OPERATORS,
+  SINGLE_CHAR_OPERATORS,
+  PUNCTUATION_TOKENS,
+  WHITESPACE_PATTERN,
+  DIGIT_PATTERN,
+  DIGIT_OR_DOT_PATTERN,
+  WORD_START_PATTERN,
+  WORD_CHAR_PATTERN,
+} from './Constants';
+
+export class Tokenizer {
+  private readonly input: string;
+  private pos = 0;
+
+  constructor(input: string) {
+    this.input = input;
+  }
+
+  tokenize(): Token[] {
+    const tokens: Token[] = [];
+
+    while (this.pos < this.input.length) {
+      this.skipWhitespace();
+      if (this.pos >= this.input.length) break;
+
+      const token = this.readNextToken();
+      if (token) {
+        tokens.push(token);
+      }
+    }
+
+    tokens.push({ type: TokenType.Eof, value: '', pos: this.input.length });
+    return tokens;
+  }
+
+  private peek(): string {
+    return this.input[this.pos];
+  }
+
+  private peekAt(offset: number): string | undefined {
+    return this.input[this.pos + offset];
+  }
+
+  private advance(): string {
+    return this.input[this.pos++];
+  }
+
+  private skipWhitespace(): void {
+    while (this.pos < this.input.length && WHITESPACE_PATTERN.test(this.input[this.pos])) {
+      ++this.pos;
+    }
+  }
+
+  private readNextToken(): Token | null {
+    const startPos = this.pos;
+    const char = this.peek();
+
+    if (char === "'") return this.readStringLiteral(startPos);
+
+    const punctuation = PUNCTUATION_TOKENS.get(char);
+    if (punctuation) {
+      this.advance();
+      return { type: punctuation, value: char, pos: startPos };
+    }
+
+    const operator = this.tryReadOperator(startPos);
+    if (operator) return operator;
+
+    if (this.isNumberStart()) return this.readNumberLiteral(startPos);
+    if (WORD_START_PATTERN.test(char)) return this.readWord(startPos);
+
+    // Skip unknown characters
+    this.advance();
+    return null;
+  }
+
+  private readStringLiteral(startPos: number): Token {
+    const singleQuote = "'";
+    this.advance(); // skip opening quote
+    let value = '';
+    while (this.pos < this.input.length) {
+      if (this.peek() === singleQuote && this.peekAt(1) === singleQuote) {
+        value += singleQuote;
+        this.pos += 2;
+      } else if (this.peek() === singleQuote) {
+        this.advance(); // skip closing quote
+        break;
+      } else {
+        value += this.advance();
+      }
+    }
+    return { type: TokenType.String, value, pos: startPos };
+  }
+
+  private tryReadOperator(startPos: number): Token | null {
+    // Try two-character operators first
+    if (this.pos + 1 < this.input.length) {
+      const twoChar = this.input.slice(this.pos, this.pos + 2);
+      const canonical = TWO_CHAR_OPERATORS.get(twoChar);
+      if (canonical) {
+        this.pos += 2;
+        return { type: TokenType.Operator, value: canonical, pos: startPos };
+      }
+    }
+
+    // Try single-character operators
+    if (SINGLE_CHAR_OPERATORS.has(this.peek())) {
+      const value = this.advance();
+      return { type: TokenType.Operator, value, pos: startPos };
+    }
+
+    return null;
+  }
+
+  private isNumberStart(): boolean {
+    const char = this.peek();
+    const negativeSign = '-';
+    if (DIGIT_PATTERN.test(char)) return true;
+    return char === negativeSign && this.peekAt(1) !== undefined && DIGIT_PATTERN.test(this.peekAt(1)!);
+  }
+
+  private readNumberLiteral(startPos: number): Token {
+    const negativeSign = '-';
+    let value = '';
+    if (this.peek() === negativeSign) {
+      value += this.advance();
+    }
+    while (this.pos < this.input.length && DIGIT_OR_DOT_PATTERN.test(this.peek())) {
+      value += this.advance();
+    }
+    return { type: TokenType.Number, value, pos: startPos };
+  }
+
+  private readWord(startPos: number): Token {
+    let word = '';
+    while (this.pos < this.input.length && WORD_CHAR_PATTERN.test(this.peek())) {
+      word += this.advance();
+    }
+
+    const upper = word.toUpperCase();
+
+    // TIMESTAMP is special: consumes the following string literal
+    if (upper === TIMESTAMP_KEYWORD) {
+      return this.readTimestampOrIdent(word, startPos);
+    }
+
+    // Check if the word is a recognized SQL keyword
+    const keywordType = KEYWORD_TOKENS.get(upper);
+    if (keywordType) {
+      return { type: keywordType, value: upper, pos: startPos };
+    }
+
+    return { type: TokenType.Ident, value: word, pos: startPos };
+  }
+
+  private readTimestampOrIdent(word: string, startPos: number): Token {
+    const singleQuote = "'";
+    this.skipWhitespace();
+    if (this.pos < this.input.length && this.peek() === singleQuote) {
+      this.advance(); // skip opening quote
+      let timestamp = '';
+      while (this.pos < this.input.length && this.peek() !== singleQuote) {
+        timestamp += this.advance();
+      }
+      if (this.pos < this.input.length) {
+        this.advance(); // skip closing quote
+      }
+      return { type: TokenType.Timestamp, value: timestamp, pos: startPos };
+    }
+
+    // Not followed by a string literal — treat as identifier
+    return { type: TokenType.Ident, value: word, pos: startPos };
+  }
+}

--- a/src/expressions/parsing/Tokenizer.ts
+++ b/src/expressions/parsing/Tokenizer.ts
@@ -25,8 +25,10 @@ export class Tokenizer {
     this.input = input;
   }
 
+  private tokens: Token[] = [];
+
   tokenize(): Token[] {
-    const tokens: Token[] = [];
+    this.tokens = [];
 
     while (this.pos < this.input.length) {
       this.skipWhitespace();
@@ -34,12 +36,16 @@ export class Tokenizer {
 
       const token = this.readNextToken();
       if (token) {
-        tokens.push(token);
+        this.tokens.push(token);
       }
     }
 
-    tokens.push({ type: TokenType.Eof, value: '', pos: this.input.length });
-    return tokens;
+    this.tokens.push({ type: TokenType.Eof, value: '', pos: this.input.length });
+    return this.tokens;
+  }
+
+  private previousTokenType(): TokenType | null {
+    return this.tokens.length > 0 ? this.tokens[this.tokens.length - 1].type : null;
   }
 
   private peek(): string {
@@ -125,7 +131,15 @@ export class Tokenizer {
     const char = this.peek();
     const negativeSign = '-';
     if (DIGIT_PATTERN.test(char)) return true;
-    return char === negativeSign && this.peekAt(1) !== undefined && DIGIT_PATTERN.test(this.peekAt(1)!);
+    // Only treat '-' as a negative sign when preceded by an operator, opening
+    // paren, comma, or at the very start of the input — never immediately
+    // after an identifier or number (e.g. "x >-5" should tokenize as '>' then '-5',
+    // but "x-5" should not swallow the '-5' as a standalone negative number).
+    if (char === negativeSign && this.peekAt(1) !== undefined && DIGIT_PATTERN.test(this.peekAt(1)!)) {
+      const prev = this.previousTokenType();
+      return prev === null || prev === TokenType.Operator || prev === TokenType.LeftParen || prev === TokenType.Comma;
+    }
+    return false;
   }
 
   private readNumberLiteral(startPos: number): Token {

--- a/src/expressions/parsing/Tokenizer.ts
+++ b/src/expressions/parsing/Tokenizer.ts
@@ -104,8 +104,8 @@ export class Tokenizer {
   private tryReadOperator(startPos: number): Token | null {
     // Try two-character operators first
     if (this.pos + 1 < this.input.length) {
-      const twoChar = this.input.slice(this.pos, this.pos + 2);
-      const canonical = TWO_CHAR_OPERATORS.get(twoChar);
+      const twoCharSlice = this.input.slice(this.pos, this.pos + 2);
+      const canonical = TWO_CHAR_OPERATORS.get(twoCharSlice);
       if (canonical) {
         this.pos += 2;
         return { type: TokenType.Operator, value: canonical, pos: startPos };

--- a/src/expressions/parsing/index.ts
+++ b/src/expressions/parsing/index.ts
@@ -1,0 +1,4 @@
+export { parse } from './Parser';
+export { TokenType } from './Constants';
+export type { Token } from './Constants';
+export { Tokenizer } from './Tokenizer';

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,5 @@ export { AudiomMessageHandler } from './AudiomMessages';
 export type {
   AudiomOutboundMessage,
 } from './AudiomMessages';
+
+export * from './expressions';


### PR DESCRIPTION
## Summary

Adds a `src/expressions/` module providing a strongly-typed, composable expression AST for building feature query filters. Closes #4.

## What's included

### Core Expression AST (`Expression.ts`)
- Discriminated union of expression node types: `ComparisonExpr`, `LogicalExpr`, `NotExpr`, `LikeExpr`, `InExpr`, `BetweenExpr`, `IsNullExpr`, `RawExpr`
- `ComparisonOp` and `LogicalOp` enums mapping to SQL-92 operators

### Fluent builder API (`AttributeFilter.ts`)
- `field(name)` → `.eq()`, `.neq()`, `.gt()`, `.lt()`, `.gte()`, `.lte()`, `.like()`, `.notLike()`, `.in()`, `.notIn()`, `.between()`, `.notBetween()`, `.isNull()`, `.isNotNull()`
- `and()`, `or()`, `not()` logical combinators
- `raw()` escape hatch for vendor-specific SQL (with security doc warning)

### Serializer (`Serialize.ts`)
- AST → Esri SQL-92 string with correct operator precedence, parenthesization, single-quote escaping, TIMESTAMP literal formatting, and boolean → `1`/`0` conversion

### Parser (`parsing/`)
- Tokenizer + recursive descent parser: SQL string → Expression AST
- Supports all node types, operator precedence (OR < AND < NOT), parenthesized groups
- Falls back to `RawExpr` for unrecognized syntax instead of throwing

### Spatial filter (`SpatialFilter.ts`)
- `SpatialRelationship`, `GeometryType`, `DistanceUnit` enums
- Static builders: `intersects()`, `contains()`, `within()`, `withinDistance()`, `fromEnvelope()`
- Serializes to Esri query parameters

### Temporal filter (`TemporalFilter.ts`)
- `TimeInstant`, `TimeExtent` with epoch-ms and Date construction
- `interval()` / `intervalToString()` for `CURRENT_TIMESTAMP +/- INTERVAL` syntax
- Open-ended ranges via `null` start/end

### Integration
- `AudiomSource.where` accepts `Expression` (serialized via `toString()` in `toQueryParams()`)
- `AudiomSource.spatialFilter` and `AudiomSource.time` properties
- Everything re-exported through `src/expressions/index.ts` → `src/index.ts`

### Documentation
- Expression filter examples added to `src/README.md`
- Root `README.md` updated to match current API signatures

## Tests

All 256 tests pass, including:
- AST type shape tests
- Builder API tests for every `FieldRef` method and logical combinator
- Serialization tests covering all node types, escaping, nesting, and Date/TIMESTAMP handling
- Parser tests for all supported syntax, precedence, fallback to `RawExpr`
- Round-trip tests (`toString(parse(sql)) === sql`)
- Spatial filter builder and `toQueryParams()` tests
- Temporal filter construction and serialization tests
- `AudiomSource` integration tests with typed expressions